### PR TITLE
Improve OCR confidence and reduce price display latency

### DIFF
--- a/src/PoeAncientsPriceHelper.Tests/OcrScannerTests.cs
+++ b/src/PoeAncientsPriceHelper.Tests/OcrScannerTests.cs
@@ -59,4 +59,16 @@ public class OcrScannerTests
     {
         Assert.Equal(expected, OcrScanner.ExtractMultiplier(input));
     }
+
+    [Theory]
+    [InlineData("3x orb of alchemy", 3, true)]
+    [InlineData("1x orb of alchemy", 1, true)]
+    [InlineData("orb of alchemy", 1, false)]
+    [InlineData("warding rune of protection i", 1, false)]
+    public void ExtractMultiplierWithConfidence_TracksExplicitMarker(string input, int expectedMultiplier, bool expectedExplicit)
+    {
+        var (multiplier, explicitHit) = OcrScanner.ExtractMultiplierWithConfidence(input);
+        Assert.Equal(expectedMultiplier, multiplier);
+        Assert.Equal(expectedExplicit, explicitHit);
+    }
 }

--- a/src/PoeAncientsPriceHelper.Tests/ScanEngineQuantityTests.cs
+++ b/src/PoeAncientsPriceHelper.Tests/ScanEngineQuantityTests.cs
@@ -1,0 +1,45 @@
+using PoeAncientsPriceHelper;
+
+namespace PoeAncientsPriceHelper.Tests;
+
+public class ScanEngineQuantityTests
+{
+    [Theory]
+    [InlineData(3, true, 1, 1, 3)]
+    [InlineData(1, false, 3, 1, 3)]
+    [InlineData(1, false, 1, 3, 3)]
+    [InlineData(1, true, 1, 3, 1)]
+    [InlineData(1, false, 1, 1, 1)]
+    public void ResolveMultiplierForDisplay_PrefersReliableStackSignal(
+        int readMultiplier,
+        bool readExplicit,
+        int priorLocked,
+        int remembered,
+        int expected)
+    {
+        int actual = ScanEngine.ResolveMultiplierForDisplay(readMultiplier, readExplicit, priorLocked, remembered);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ScorePriceConfidence_PenalizesUncertainSingleAndRewardsLockedExplicit()
+    {
+        double uncertainSingle = ScanEngine.ScorePriceConfidence(
+            exactMatch: false,
+            locked: false,
+            multiplierExplicit: false,
+            multiplier: 1,
+            usedMemory: false);
+
+        double lockedExplicitStack = ScanEngine.ScorePriceConfidence(
+            exactMatch: true,
+            locked: true,
+            multiplierExplicit: true,
+            multiplier: 3,
+            usedMemory: false);
+
+        Assert.True(lockedExplicitStack > uncertainSingle);
+        Assert.InRange(lockedExplicitStack, 0.9, 1.0);
+        Assert.InRange(uncertainSingle, 0.0, 0.7);
+    }
+}

--- a/src/PoeAncientsPriceHelper/OcrScanner.cs
+++ b/src/PoeAncientsPriceHelper/OcrScanner.cs
@@ -1,13 +1,15 @@
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Globalization;
 using Windows.Graphics.Imaging;
 using Windows.Media.Ocr;
 
 namespace PoeAncientsPriceHelper;
 
-internal sealed record OcrRow(string NormalizedName, string RawText, int CenterY, int Multiplier = 1);
+internal sealed record OcrRow(string NormalizedName, string RawText, int CenterY,
+                              int Multiplier = 1, bool MultiplierExplicit = false);
 
 internal sealed class OcrScanner
 {
@@ -62,6 +64,12 @@ internal sealed class OcrScanner
         var result = _engine.RecognizeAsync(softwareBitmap).AsTask().GetAwaiter().GetResult();
         var rows = ExtractRows(result, height, scale);
 
+        // Quantity prefix-only OCR: read the left band separately and merge explicit Nx hits by row Y.
+        using var prefixBand = CropBitmap(upscaled, 0, 0, Math.Max(1, (int)(upscaled.Width * 0.22)), upscaled.Height);
+        using var prefixBitmap = ToSoftwareBitmap(prefixBand);
+        var prefixResult = _engine.RecognizeAsync(prefixBitmap).AsTask().GetAwaiter().GetResult();
+        rows = MergePrefixMultipliers(rows, ExtractPrefixMultipliers(prefixResult, height, scale));
+
         // When OCR catches few rows, dump the exact image fed to Windows OCR for inspection. Debug-only:
         // for end users this would be needless disk churn (~every 100ms while a panel mis-detects).
         if (_debug && rows.Count <= 2)
@@ -79,6 +87,49 @@ internal sealed class OcrScanner
         int byWidth = maxDim / Math.Max(1, bitmap.Width);
         int byHeight = maxDim / Math.Max(1, bitmap.Height);
         return Math.Max(1, Math.Min(UpscaleFactor, Math.Min(byWidth, byHeight)));
+    }
+
+    private static IReadOnlyList<(int CenterY, int Multiplier)> ExtractPrefixMultipliers(OcrResult result, int bitmapHeight, int scale)
+    {
+        var hits = new List<(int CenterY, int Multiplier)>();
+        foreach (var line in result.Lines)
+        {
+            if (string.IsNullOrWhiteSpace(line.Text) || line.Words.Count == 0) continue;
+            var normalized = NameNormalizer.Normalize(line.Text);
+            var (mult, explicitHit) = ExtractMultiplierWithConfidence(normalized);
+            if (!explicitHit) continue;
+            int centerY = GetLineCenterY(line, bitmapHeight, scale);
+            hits.Add((centerY, mult));
+        }
+        return hits;
+    }
+
+    private static IReadOnlyList<OcrRow> MergePrefixMultipliers(
+        IReadOnlyList<OcrRow> rows,
+        IReadOnlyList<(int CenterY, int Multiplier)> prefixHits)
+    {
+        if (rows.Count == 0 || prefixHits.Count == 0) return rows;
+        const int Tol = 22;
+        var list = rows.ToList();
+        var used = new bool[prefixHits.Count];
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (list[i].MultiplierExplicit) continue;
+            int best = int.MaxValue;
+            int bestIdx = -1;
+            for (int j = 0; j < prefixHits.Count; j++)
+            {
+                if (used[j]) continue;
+                int d = Math.Abs(prefixHits[j].CenterY - list[i].CenterY);
+                if (d <= Tol && d < best) { best = d; bestIdx = j; }
+            }
+            if (bestIdx >= 0)
+            {
+                used[bestIdx] = true;
+                list[i] = list[i] with { Multiplier = prefixHits[bestIdx].Multiplier, MultiplierExplicit = true };
+            }
+        }
+        return list;
     }
 
     private static Bitmap CropBitmap(Bitmap src, int x, int y, int w, int h)
@@ -114,15 +165,20 @@ internal sealed class OcrScanner
             {
                 centerY = GetLineCenterY(line, bitmapHeight, scale);
                 var normalizedRaw = NameNormalizer.Normalize(text);
-                multiplier = ExtractMultiplier(normalizedRaw);
+                var parsed = ExtractMultiplierWithConfidence(normalizedRaw);
+                multiplier = parsed.Multiplier;
+                bool multiplierExplicit = parsed.Explicit;
                 normalized = StripLeadingNoise(normalizedRaw);
                 if (normalized.Length < MinNameLength) reject = "short";
                 else if (!HasLongWord(normalized, MinWordLength)) reject = "noword";
+
+                if (reject is null)
+                    rows.Add(new OcrRow(normalized, text.Trim(), centerY, multiplier, multiplierExplicit));
+                diag?.Add($"y={centerY} words={line.Words.Count} '{(text ?? "").Trim()}'{(reject is null ? "" : $" REJ:{reject}")}");
+                continue;
             }
 
-            if (reject is null)
-                rows.Add(new OcrRow(normalized, text.Trim(), centerY, multiplier));
-            diag?.Add($"y={centerY} words={line.Words.Count} '{(text ?? "").Trim()}'{(reject is null ? "" : $" REJ:{reject}")}");
+            diag?.Add($"y=0 words=0 '{(text ?? "").Trim()}'{(reject is null ? "" : $" REJ:{reject}")}");
         }
 
         rows.Sort((x, y) => x.CenterY.CompareTo(y.CenterY));
@@ -163,10 +219,15 @@ internal sealed class OcrScanner
     // normalized string BEFORE StripLeadingNoise removes the marker. Returns 1 when absent.
     internal static int ExtractMultiplier(string normalized)
     {
+        return ExtractMultiplierWithConfidence(normalized).Multiplier;
+    }
+
+    internal static (int Multiplier, bool Explicit) ExtractMultiplierWithConfidence(string normalized)
+    {
         var m = MultiplierPattern.Match(normalized);
         if (m.Success && int.TryParse(m.Groups[1].Value, out var n) && n >= 1)
-            return Math.Min(n, 999);
-        return 1;
+            return (Math.Min(n, 999), true);
+        return (1, false);
     }
 
     // Strip leading noise: short/numeric tokens ("e", "l8"), then anything before the first

--- a/src/PoeAncientsPriceHelper/PriceOverlay.cs
+++ b/src/PoeAncientsPriceHelper/PriceOverlay.cs
@@ -17,7 +17,10 @@ namespace PoeAncientsPriceHelper;
 //   Headhunter — OCR'd "unique belt"        → Headhunter icon + "Headhunter!".
 internal enum MemeKind { None, Mirror, Headhunter }
 
-internal sealed record PriceRow(int CenterY, string OcrText, decimal DivineValue, decimal ExaltedValue, bool HasPrice, int Multiplier = 1, string Name = "", bool ExactMatch = false, MemeKind Meme = MemeKind.None);
+internal sealed record PriceRow(int CenterY, string OcrText, decimal DivineValue, decimal ExaltedValue, bool HasPrice,
+                                int Multiplier = 1, string Name = "", bool ExactMatch = false,
+                                MemeKind Meme = MemeKind.None, bool MultiplierExplicit = false,
+                                double Confidence = 0.0);
 
 internal sealed class PriceOverlayForm : Form
 {
@@ -30,6 +33,8 @@ internal sealed class PriceOverlayForm : Form
     private IReadOnlyList<PriceRow> _lastRenderedRows = [];
     private bool _lastPanelOpen;
     private bool _lastReading;
+    private string _debugHud = "";
+    private string _lastDebugHud = "";
     private readonly IconCache _icons;
     private readonly Rectangle _regionRect;
     private readonly int _xOffset;
@@ -72,13 +77,14 @@ internal sealed class PriceOverlayForm : Form
         }
     }
 
-    public void UpdateState(IReadOnlyList<PriceRow> rows, bool panelOpen, bool reading)
+    public void UpdateState(IReadOnlyList<PriceRow> rows, bool panelOpen, bool reading, string? debugHud)
     {
         if (IsDisposed) return;
-        if (InvokeRequired) { BeginInvoke(() => UpdateState(rows, panelOpen, reading)); return; }
+        if (InvokeRequired) { BeginInvoke(() => UpdateState(rows, panelOpen, reading, debugHud)); return; }
         _rows = rows;
         _panelOpen = panelOpen;
         _reading = reading;
+        _debugHud = debugHud ?? "";
 
         // ApplyVisibility must run on every visibility transition (show/hide) even if the rows are
         // unchanged; RenderLayered only needs to run when something the user can see actually changed.
@@ -86,14 +92,16 @@ internal sealed class PriceOverlayForm : Form
         bool visibilityChanged = shouldShow != Visible;
         bool rowsChanged = !_rows.SequenceEqual(_lastRenderedRows);
         bool stateChanged = _panelOpen != _lastPanelOpen || _reading != _lastReading;
+        bool hudChanged = _debugHud != _lastDebugHud;
 
-        if (visibilityChanged || rowsChanged || stateChanged)
+        if (visibilityChanged || rowsChanged || stateChanged || hudChanged)
         {
             ApplyVisibility(shouldShow);
             if (Visible) RenderLayered();
             _lastRenderedRows = _rows.ToArray();  // snapshot to avoid aliasing the scan loop's buffer
             _lastPanelOpen = _panelOpen;
             _lastReading = _reading;
+            _lastDebugHud = _debugHud;
         }
     }
 
@@ -104,6 +112,7 @@ internal sealed class PriceOverlayForm : Form
         if (InvokeRequired) { BeginInvoke(ToggleDebug); return; }
         _debug = !_debug;
         _lastRenderedRows = [];   // invalidate cache so the next UpdateState forces a fresh render
+        _lastDebugHud = "";
         ApplyVisibility(_panelOpen || _reading || _debug);
         if (Visible) RenderLayered();
     }
@@ -129,6 +138,7 @@ internal sealed class PriceOverlayForm : Form
         _lastPanelOpen = false;
         _lastReading = false;
         _lastRenderedRows = [];
+        _lastDebugHud = "";
         ApplyVisibility(_debug);
         if (Visible) RenderLayered();
     }
@@ -201,6 +211,11 @@ internal sealed class PriceOverlayForm : Form
             var borderColor = _panelOpen ? Color.LimeGreen : Color.Orange;
             using var borderPen = new Pen(borderColor, 2);
             g.DrawRectangle(borderPen, _regionRect);
+            if (!string.IsNullOrWhiteSpace(_debugHud))
+            {
+                using var hudBrush = new SolidBrush(Color.FromArgb(220, 220, 220));
+                g.DrawString(_debugHud, _debugFont, hudBrush, _regionRect.Left + 6, _regionRect.Top + 6);
+            }
         }
 
         if (!_panelOpen) return;
@@ -476,8 +491,11 @@ internal static class PriceOverlayManager
     public static void Hide() =>
         WithForm(f => f.Invoke(() => { if (!f.IsDisposed) f.Close(); }));
 
+    public static void UpdateState(IReadOnlyList<PriceRow> rows, bool panelOpen, bool reading, string? debugHud = null) =>
+        WithForm(f => f.UpdateState(rows, panelOpen, reading, debugHud));
+
     public static void UpdateState(IReadOnlyList<PriceRow> rows, bool panelOpen, bool reading) =>
-        WithForm(f => f.UpdateState(rows, panelOpen, reading));
+        WithForm(f => f.UpdateState(rows, panelOpen, reading, null));
 
     public static void ForceTopmost() => WithForm(f => f.ForceTopmost());
 

--- a/src/PoeAncientsPriceHelper/ScanEngine.cs
+++ b/src/PoeAncientsPriceHelper/ScanEngine.cs
@@ -87,12 +87,8 @@ internal sealed class ScanEngine : IDisposable
         var sw = Stopwatch.StartNew();
         var slots = new List<RowSlot>();             // per-row accumulator: priced rows lock, misses keep retrying
         IReadOnlyList<PriceRow> lastRows = [];       // what the overlay shows
-        // Last state actually pushed to the overlay. The loop ticks ~10×/s but the displayed rows
-        // only change when OCR resolves something new, so skipping UpdateState when nothing changed
-        // avoids needless cross-thread marshalling / repaints on the hot path.
-        IReadOnlyList<PriceRow> lastPushedRows = [];
-        bool lastPushedConfirmed = false;
-        bool lastPushedReading = false;
+        var quantityMemory = new Dictionary<string, (int Multiplier, DateTime ExpiresUtc)>(StringComparer.Ordinal);
+        var scrollHoldoffUntil = DateTime.MinValue;
         int topmostCounter = 0;
         const int TopmostEveryN = 10;
         bool isOpen = false;          // brightness gate: bright enough to attempt OCR
@@ -106,13 +102,14 @@ internal sealed class ScanEngine : IDisposable
         int brightStreak = 0;
         int darkStreak = 0;
         int dismissDark = 0;          // dark frames seen while dismissed — releases the latch when the panel closes
-        int staleCount = 0;           // consecutive 0-row OCR passes — clears stale overlay on loading screens
-        const int StaleLimit = 10;    // consecutive 0-row OCR passes before clearing (~800ms at 80ms interval)
         int cycleCount = 0;
         var lastOcrAt = DateTime.MinValue;
-        const int MinOcrIntervalMs = 150;            // OCR floor while panel is open — Windows OCR is fast enough that 6.7/s gives sub-200ms turnaround
-        const int OpenCycleMs = 120;                 // tight loop while scanning
-        const int ClosedCycleMs = 300;               // polling while watching for the panel — halves idle capture cost
+        int ocrEmptyStreak = 0;                      // consecutive OCR passes with no usable priced rows
+        const int MinOcrIntervalMs = 75;             // OCR floor while panel is open — faster refresh while scrolling
+        const int OpenCycleMs = 75;                  // tight loop while scanning
+        const int ClosedCycleMs = 150;               // polling while watching for the panel — snappy detection
+        const int ClearAfterEmptyOcr = 2;            // clear stale rows after ~200 ms of consecutive OCR misses
+        const int ScrollHoldoffMs = 125;             // suppress low-confidence rows briefly during active scroll motion
         const int DarkToRelease = 3;                 // dark frames before a dismiss latch releases
         // Asymmetric brightness hysteresis. A frame counts toward OPENING only above OpenBrightness and
         // toward CLOSING only below CloseBrightness; readings in the [80,100] dead zone hold the current
@@ -152,13 +149,12 @@ internal sealed class ScanEngine : IDisposable
                         Log("dismiss released (panel closed)");
                     }
                     isOpen = false; confirmedOpen = false; brightStreak = 0; darkStreak = 0;
+                    ocrEmptyStreak = 0;
+                    quantityMemory.Clear();
+                    scrollHoldoffUntil = DateTime.MinValue;
                     slots.Clear(); lastRows = [];
-                    staleCount = 0;
                     _showing = false;
-                    // Always push when dismissed to clear the overlay, and reset the change-tracker
-                    // so the next real state is treated as new.
-                    PriceOverlayManager.UpdateState([], false, false);
-                    lastPushedRows = []; lastPushedConfirmed = false; lastPushedReading = false;
+                    PriceOverlayManager.UpdateState([], false, false, null);
                 }
                 else
                 {
@@ -205,26 +201,19 @@ internal sealed class ScanEngine : IDisposable
                             var ocrRows = scanner.Scan(bmp);
                             if (ocrRows.Count == 0)
                             {
-                                staleCount++;
-                                // Hide stale prices quickly (after 2 passes ≈ 160ms) so they don't
-                                // linger on loading screens, but keep slots alive until StaleLimit
-                                // for fast recovery when the panel reappears.
-                                if (staleCount >= 2)
-                                    lastRows = [];
-                                if (staleCount >= StaleLimit)
+                                // Panel mid-animation or a bad frame. Keep rows for one miss to avoid
+                                // flicker, but clear stale prices if misses persist.
+                                ocrEmptyStreak++;
+                                if (ocrEmptyStreak >= ClearAfterEmptyOcr)
                                 {
-                                    Log($"OCR 0 rows for {staleCount} passes — clearing slots");
                                     slots.Clear();
+                                    lastRows = [];
                                     confirmedOpen = false;
                                 }
-                                else
-                                {
-                                    Log($"OCR 0 rows ({staleCount}/{StaleLimit})");
-                                }
+                                Log("OCR returned 0 rows");
                             }
                             else
                             {
-                                staleCount = 0;
                                 var reads = BuildPriceRows(ocrRows);
                                 Log($"OCR {ocrRows.Count} rows → " +
                                     string.Join(" | ", reads.Select(r =>
@@ -240,33 +229,48 @@ internal sealed class ScanEngine : IDisposable
                                     Log("panel CONFIRMED (priced row found)");
                                 }
 
-                                lastRows = MergeReads(slots, reads);
+                                // No priced rows in consecutive OCR passes usually means stale content;
+                                // clear locked rows quickly so old prices don't linger on-screen.
+                                if (reads.Any(r => r.HasPrice)) ocrEmptyStreak = 0;
+                                else if (++ocrEmptyStreak >= ClearAfterEmptyOcr)
+                                {
+                                    slots.Clear();
+                                    lastRows = [];
+                                    confirmedOpen = false;
+                                }
+
+                                // Per-row slots: a row locks once confirmed, then stays fixed;
+                                // unpriced rows keep being retried every pass.
+                                lastRows = MergeReads(slots, reads, quantityMemory, now, out bool scrollDetected);
+                                if (scrollDetected) scrollHoldoffUntil = now.AddMilliseconds(ScrollHoldoffMs);
+                                if (now < scrollHoldoffUntil)
+                                {
+                                    lastRows = lastRows.Select(r =>
+                                        r.HasPrice && r.Confidence < 0.85 && r.Multiplier <= 1 && !r.MultiplierExplicit
+                                            ? r with { HasPrice = false, DivineValue = 0m, ExaltedValue = 0m }
+                                            : r).ToList();
+                                }
                             }
                         }
                     }
                     else
                     {
+                        ocrEmptyStreak = 0;
+                        quantityMemory.Clear();
+                        scrollHoldoffUntil = DateTime.MinValue;
                         slots.Clear();
                         lastRows = [];
                         confirmedOpen = false;
-                        staleCount = 0;
                     }
 
                     // "reading" = brightness says a panel is up but OCR hasn't confirmed prices yet.
                     // Suppressed straight after a dismiss until a real confirm (anti-flicker, see above).
                     bool reading = isOpen && !confirmedOpen && !suppressHintUntilConfirm;
+                    string hud = BuildDebugHud(lastRows, DateTime.UtcNow < scrollHoldoffUntil);
 
                     // Show prices only once OCR has confirmed a real list, not on brightness alone.
                     _showing = confirmedOpen;
-                    // Skip the cross-thread UpdateState when nothing actually changed since the last
-                    // push — the loop ticks far faster than the displayed rows move.
-                    if (!lastRows.SequenceEqual(lastPushedRows) || confirmedOpen != lastPushedConfirmed || reading != lastPushedReading)
-                    {
-                        PriceOverlayManager.UpdateState(lastRows, confirmedOpen, reading);
-                        lastPushedRows = lastRows.ToArray();
-                        lastPushedConfirmed = confirmedOpen;
-                        lastPushedReading = reading;
-                    }
+                    PriceOverlayManager.UpdateState(lastRows, confirmedOpen, reading, hud);
 
                     topmostCounter++;
                     if (topmostCounter >= TopmostEveryN)
@@ -332,10 +336,11 @@ internal sealed class ScanEngine : IDisposable
             {
                 if (gemKey is not null && snapshot.TryGetValue(gemKey, out var gemEntry))
                     rows.Add(new PriceRow(stableY, row.RawText, gemEntry.DivineValue, gemEntry.ExaltedValue,
-                        true, row.Multiplier, gemKey, true));
+                        true, row.Multiplier, gemKey, true, MemeKind.None, row.MultiplierExplicit));
                 else
                     // Recognised as an uncut gem but type+level didn't pin to a known price → '?', never fuzzy.
-                    rows.Add(new PriceRow(stableY, row.RawText, 0m, 0m, false, row.Multiplier, row.NormalizedName));
+                    rows.Add(new PriceRow(stableY, row.RawText, 0m, 0m, false,
+                        row.Multiplier, row.NormalizedName, false, MemeKind.None, row.MultiplierExplicit));
                 continue;
             }
 
@@ -345,12 +350,14 @@ internal sealed class ScanEngine : IDisposable
             //    currency") → Mirror of Kalandra. "unique belt" → Headhunter.
             if (row.NormalizedName.Contains("random") && row.NormalizedName.Contains("currency"))
             {
-                rows.Add(new PriceRow(stableY, row.RawText, 0m, 0m, true, row.Multiplier, "random currency", true, MemeKind.Mirror));
+                rows.Add(new PriceRow(stableY, row.RawText, 0m, 0m, true,
+                    row.Multiplier, "random currency", true, MemeKind.Mirror, row.MultiplierExplicit));
                 continue;
             }
             if (row.NormalizedName.Contains("unique") && row.NormalizedName.Contains("belt"))
             {
-                rows.Add(new PriceRow(stableY, row.RawText, 0m, 0m, true, row.Multiplier, "unique belt", true, MemeKind.Headhunter));
+                rows.Add(new PriceRow(stableY, row.RawText, 0m, 0m, true,
+                    row.Multiplier, "unique belt", true, MemeKind.Headhunter, row.MultiplierExplicit));
                 continue;
             }
 
@@ -408,9 +415,11 @@ internal sealed class ScanEngine : IDisposable
             }
 
             if (entry != null)
-                rows.Add(new PriceRow(stableY, row.RawText, entry.DivineValue, entry.ExaltedValue, true, row.Multiplier, matchedKey, exact));
+                rows.Add(new PriceRow(stableY, row.RawText, entry.DivineValue, entry.ExaltedValue, true,
+                    row.Multiplier, matchedKey, exact, MemeKind.None, row.MultiplierExplicit));
             else
-                rows.Add(new PriceRow(stableY, row.RawText, 0m, 0m, false, row.Multiplier, row.NormalizedName));
+                rows.Add(new PriceRow(stableY, row.RawText, 0m, 0m, false,
+                    row.Multiplier, row.NormalizedName, false, MemeKind.None, row.MultiplierExplicit));
         }
         _lastPositions = newPositions;
         return rows;
@@ -506,11 +515,34 @@ internal sealed class ScanEngine : IDisposable
         public int Unseen;               // consecutive passes this slot wasn't matched
     }
 
-    private IReadOnlyList<PriceRow> MergeReads(List<RowSlot> slots, IReadOnlyList<PriceRow> reads)
+    private IReadOnlyList<PriceRow> MergeReads(
+        List<RowSlot> slots,
+        IReadOnlyList<PriceRow> reads,
+        Dictionary<string, (int Multiplier, DateTime ExpiresUtc)> quantityMemory,
+        DateTime nowUtc,
+        out bool scrollDetected)
     {
         const int Tolerance = 20;   // px: how far a read can move and still be the same row
         const int Confirm = 2;      // matching fuzzy/prefix reads before a row locks (exact: 1)
-        const int EvictAfter = 3;   // passes a slot can go unmatched before it's dropped
+        const int EvictAfter = 1;   // passes a slot can go unmatched before it's dropped (faster scroll cleanup)
+        const int NearDuplicateY = 18; // px: unmatched stale slot near a matched slot is removed immediately
+        const int UncertainSingleConfirm = 8; // uncertain 1x reads need stability before locking/rendering
+        const double RenderThreshold = 0.72;
+
+        scrollDetected = false;
+
+        // Trim expired quantity memory in-place.
+        foreach (var key in quantityMemory.Where(kv => kv.Value.ExpiresUtc <= nowUtc)
+                                          .Select(kv => kv.Key)
+                                          .ToList())
+            quantityMemory.Remove(key);
+
+        static string? SlotName(RowSlot s)
+        {
+            if (s.Locked && !string.IsNullOrEmpty(s.LockedRow.Name)) return s.LockedRow.Name;
+            if (s.Latest.HasPrice && !string.IsNullOrEmpty(s.Latest.Name)) return s.Latest.Name;
+            return null;
+        }
 
         // Panel-switch detection: the user opened a different panel without the overlay closing.
         // Locked rows are otherwise sticky (a miss never unlocks them), so they'd keep showing the
@@ -534,10 +566,34 @@ internal sealed class ScanEngine : IDisposable
         }
 
         var matched = new HashSet<RowSlot>();
+        int movedByScrollCount = 0;
         foreach (var read in reads)
         {
             RowSlot? slot = null;
             int best = int.MaxValue;
+            bool matchedByName = false;
+            bool movedByScroll = false;
+
+            // Scroll support: if the same priced item is read at a very different Y, reuse that
+            // existing slot by name and move it, instead of creating a second slot nearby.
+            if (read.HasPrice && !string.IsNullOrEmpty(read.Name))
+            {
+                foreach (var s in slots)
+                {
+                    if (matched.Contains(s)) continue;
+                    if (!string.Equals(SlotName(s), read.Name, StringComparison.Ordinal)) continue;
+                    int d = Math.Abs(s.Y - read.CenterY);
+                    if (d < best) { best = d; slot = s; }
+                }
+                if (slot is not null)
+                {
+                    matchedByName = true;
+                    movedByScroll = best > Tolerance;
+                    if (movedByScroll) movedByScrollCount++;
+                    slot.Y = read.CenterY;
+                }
+            }
+
             foreach (var s in slots)
             {
                 if (matched.Contains(s)) continue;
@@ -560,13 +616,55 @@ internal sealed class ScanEngine : IDisposable
 
                 // Exact dictionary matches are trustworthy enough to lock immediately; only the
                 // uncertain fuzzy/prefix matches need a second confirming read.
-                int needed = read.ExactMatch ? 1 : Confirm;
+                // While scrolling, re-matched items can move by >Tolerance; lock immediately so
+                // refreshed prices appear without waiting an extra pass.
+                int needed = read.Multiplier > 1
+                    ? 1
+                    : (!read.MultiplierExplicit
+                        ? UncertainSingleConfirm
+                        : (read.ExactMatch || (matchedByName && movedByScroll) ? 1 : Confirm));
                 if (slot.PendingCount >= needed)
                 {
                     if (!slot.Locked || slot.LockedRow.Name != read.Name)
                         Log($"locked y={slot.Y} '{read.Name}'");
+
+                    // OCR can intermittently miss the leading Nx marker on stack rows.
+                    // Once a locked row has seen a stack multiplier, keep it sticky if a
+                    // later pass reads the same item as 1x, so the price label doesn't
+                    // oscillate between unit-only and total(each).
+                    int remembered = RememberedMultiplier(quantityMemory, read.Name, nowUtc);
+                    int priorLockedMultiplier = slot.Locked && slot.LockedRow.Name == read.Name
+                        ? slot.LockedRow.Multiplier
+                        : 1;
+                    int effectiveMultiplier = ResolveMultiplierForDisplay(
+                        read.Multiplier,
+                        read.MultiplierExplicit,
+                        priorLockedMultiplier,
+                        remembered);
+
+                    bool effectiveMultiplierExplicit = read.MultiplierExplicit;
+                    if (effectiveMultiplier > 1 && slot.Locked && slot.LockedRow.Name == read.Name)
+                        effectiveMultiplierExplicit = slot.LockedRow.MultiplierExplicit || read.MultiplierExplicit;
+                    bool usedMemory = effectiveMultiplier > 1 && read.Multiplier == 1 && !read.MultiplierExplicit && remembered > 1;
+
+                    if (!string.IsNullOrEmpty(read.Name) && effectiveMultiplier > 1)
+                        quantityMemory[read.Name] = (effectiveMultiplier, nowUtc.AddMilliseconds(1500));
+
+                    double confidence = ScorePriceConfidence(
+                        read.ExactMatch,
+                        locked: true,
+                        effectiveMultiplierExplicit,
+                        effectiveMultiplier,
+                        usedMemory);
+
                     slot.Locked = true;
-                    slot.LockedRow = read with { CenterY = slot.Y };
+                    slot.LockedRow = read with
+                    {
+                        CenterY = slot.Y,
+                        Multiplier = effectiveMultiplier,
+                        MultiplierExplicit = effectiveMultiplierExplicit,
+                        Confidence = confidence,
+                    };
                 }
             }
             // A miss (read.HasPrice == false) does NOT reset the pending streak. A miss means
@@ -574,6 +672,40 @@ internal sealed class ScanEngine : IDisposable
             // The streak resets only when a DIFFERENT priced name arrives (handled in the if-branch
             // above via PendingName comparison). Resetting on misses made fuzzy/prefix items un-
             // lockable whenever OCR alternated between a correct read and a fragmented read.
+        }
+
+        // Scroll-motion mode: when multiple rows are re-matched by name but shifted by more than
+        // the normal positional tolerance in the same pass, treat it as an active scroll event and
+        // drop all unmatched stale slots right away.
+        if (movedByScrollCount >= 2)
+        {
+            scrollDetected = true;
+            for (int i = slots.Count - 1; i >= 0; i--)
+                if (!matched.Contains(slots[i])) slots.RemoveAt(i);
+        }
+
+        // If a name was matched this pass, immediately drop any unmatched stale slot carrying the
+        // same name. This prevents the "double price, a few pixels apart" artifact while scrolling.
+        var liveNames = new HashSet<string>(
+            matched.Select(SlotName)
+                   .OfType<string>()
+                   .Where(n => n.Length > 0),
+            StringComparer.Ordinal);
+        for (int i = slots.Count - 1; i >= 0; i--)
+        {
+            if (matched.Contains(slots[i])) continue;
+            var n = SlotName(slots[i]);
+            if (n is not null && liveNames.Contains(n)) slots.RemoveAt(i);
+        }
+
+        // Position de-dup for scroll jitter: if an unmatched stale slot sits close to any matched
+        // slot, drop it immediately (prevents two prices a few pixels apart for one visible row).
+        for (int i = slots.Count - 1; i >= 0; i--)
+        {
+            var s = slots[i];
+            if (matched.Contains(s)) continue;
+            bool nearLive = matched.Any(m => Math.Abs(m.Y - s.Y) <= NearDuplicateY);
+            if (nearLive) slots.RemoveAt(i);
         }
 
         for (int i = slots.Count - 1; i >= 0; i--)
@@ -585,11 +717,91 @@ internal sealed class ScanEngine : IDisposable
         var display = new List<PriceRow>(slots.Count);
         foreach (var s in slots.OrderBy(s => s.Y))
         {
-            display.Add(s.Locked
-                ? s.LockedRow
-                : s.Latest with { CenterY = s.Y, HasPrice = false, DivineValue = 0m, ExaltedValue = 0m });
+            PriceRow candidate;
+            if (s.Locked)
+            {
+                candidate = s.LockedRow;
+            }
+            else if (s.Latest.HasPrice && (s.Latest.Multiplier > 1 || s.Latest.MultiplierExplicit))
+            {
+                int remembered = RememberedMultiplier(quantityMemory, s.Latest.Name, nowUtc);
+                int effectiveMultiplier = ResolveMultiplierForDisplay(
+                    s.Latest.Multiplier,
+                    s.Latest.MultiplierExplicit,
+                    priorLockedMultiplier: 1,
+                    rememberedMultiplier: remembered);
+                bool usedMemory = effectiveMultiplier > 1 && s.Latest.Multiplier == 1 && !s.Latest.MultiplierExplicit && remembered > 1;
+                bool explicitQty = s.Latest.MultiplierExplicit || (usedMemory && remembered > 1);
+                candidate = s.Latest with
+                {
+                    CenterY = s.Y,
+                    Multiplier = effectiveMultiplier,
+                    MultiplierExplicit = explicitQty,
+                    Confidence = ScorePriceConfidence(
+                        s.Latest.ExactMatch,
+                        locked: false,
+                        explicitQty,
+                        effectiveMultiplier,
+                        usedMemory),
+                };
+            }
+            else
+            {
+                candidate = s.Latest with { CenterY = s.Y, HasPrice = false, DivineValue = 0m, ExaltedValue = 0m, Confidence = 0.0 };
+            }
+
+            if (candidate.HasPrice && candidate.Confidence < RenderThreshold)
+                candidate = candidate with { HasPrice = false, DivineValue = 0m, ExaltedValue = 0m };
+
+            display.Add(candidate);
         }
         return display;
+    }
+
+    internal static int ResolveMultiplierForDisplay(
+        int readMultiplier,
+        bool readMultiplierExplicit,
+        int priorLockedMultiplier,
+        int rememberedMultiplier)
+    {
+        if (readMultiplier > 1) return readMultiplier;
+        if (priorLockedMultiplier > 1 && readMultiplier == 1) return priorLockedMultiplier;
+        if (!readMultiplierExplicit && rememberedMultiplier > 1) return rememberedMultiplier;
+        return readMultiplier;
+    }
+
+    internal static double ScorePriceConfidence(
+        bool exactMatch,
+        bool locked,
+        bool multiplierExplicit,
+        int multiplier,
+        bool usedMemory)
+    {
+        double score = locked ? 0.82 : 0.62;
+        if (exactMatch) score += 0.12;
+        if (multiplier > 1 && multiplierExplicit) score += 0.12;
+        if (usedMemory) score += 0.06;
+        if (multiplier == 1 && !multiplierExplicit) score -= 0.18;
+        return Math.Clamp(score, 0.0, 1.0);
+    }
+
+    private static int RememberedMultiplier(
+        Dictionary<string, (int Multiplier, DateTime ExpiresUtc)> quantityMemory,
+        string name,
+        DateTime nowUtc)
+    {
+        if (string.IsNullOrEmpty(name)) return 1;
+        if (!quantityMemory.TryGetValue(name, out var m)) return 1;
+        if (m.ExpiresUtc <= nowUtc) return 1;
+        return Math.Max(1, m.Multiplier);
+    }
+
+    private static string BuildDebugHud(IReadOnlyList<PriceRow> rows, bool scrollHoldoffActive)
+    {
+        int priced = rows.Count(r => r.HasPrice);
+        int explicitQty = rows.Count(r => r.HasPrice && r.MultiplierExplicit);
+        int uncertain = rows.Count(r => r.HasPrice && !r.MultiplierExplicit);
+        return $"rows={rows.Count} priced={priced} qty-exp={explicitQty} qty-unc={uncertain} scroll={(scrollHoldoffActive ? "ON" : "off")}";
     }
 
     public void Dispose()


### PR DESCRIPTION
- Stack quantity confidence tracking to distinguish explicit Nx reads from assumed 1x
- Short-lived quantity memory (1.5s) to prevent price oscillation on stacked items
- Scroll-state holdoff window to suppress low-confidence rows during active scrolling
- Per-row confidence scoring to defer weak provisional reads until stabilized
- Debug HUD (F3 mode) showing OCR row counts, quantity confidence breakdown, and scroll state
- Prefix-band OCR pass for faster explicit quantity marker detection
- Reduced variable display latency on identical items by gating uncertain single-item rows
- Eliminated flicker between unit and total prices on stacked rows via confidence + memory
- Windows OCR backend integration for faster, dependency-free text recognition