### PR TITLE
Add test coverage for uncovered PriceRepository paths

### DIFF
--- a/src/PoeAncientsPriceHelper.Tests/PriceRepositoryTests.cs
+++ b/src/PoeAncientsPriceHelper.Tests/PriceRepositoryTests.cs
@@ -138,6 +138,93 @@ public class PriceRepositoryTests
         Assert.All(handler.Referers, r => Assert.Contains(expectedSlug, r));
     }
 
+    // Items that appear on poe.ninja but have no trading data come back with primaryValue: null.
+    // They should be stored with HasMarketData: false so the overlay can show "no info" rather
+    // than hiding the row entirely — the user should know the item was recognised.
+    [Fact]
+    public async Task NullPrimaryValue_SetsHasMarketDataFalse()
+    {
+        const string response = """
+            {
+              "items": [
+                { "id": "chilling-flux", "name": "Chilling Flux" },
+                { "id": "mystery-item",  "name": "Mystery Item" }
+              ],
+              "lines": [
+                { "id": "chilling-flux", "primaryValue": 0.5 },
+                { "id": "mystery-item",  "primaryValue": null }
+              ],
+              "core": { "primary": "divine", "rates": { "exalted": 80.0 } }
+            }
+            """;
+
+        using var http = FakeHttp(response);
+        using var dir = new TempDir();
+        var repo = new PriceRepository(http);
+        await repo.InitialFetchAsync(DefaultConfig(dir.Path));
+
+        Assert.True(repo.Prices.ContainsKey("mystery item"));
+        var entry = repo.Prices["mystery item"];
+        Assert.False(entry.HasMarketData);
+        Assert.Equal(0m, entry.DivineValue);
+        Assert.Equal(0m, entry.ExaltedValue);
+
+        // The item with real data is unaffected.
+        Assert.True(repo.Prices["chilling flux"].HasMarketData);
+    }
+
+    // custom_prices.json keys are run through NameNormalizer so users can write display names
+    // ("Chilling Flux") instead of pre-normalised keys ("chilling flux") without breaking lookups.
+    [Fact]
+    public async Task CustomOverride_AcceptsUnnormalizedKey()
+    {
+        using var http = FakeHttp(FakeApiResponse);
+        using var dir = new TempDir();
+        File.WriteAllText(Path.Combine(dir.Path, "custom_prices.json"),
+            """{"Chilling Flux":{"divineValue":3.0,"exaltedValue":240.0}}""");
+
+        var repo = new PriceRepository(http);
+        await repo.InitialFetchAsync(DefaultConfig(dir.Path));
+
+        Assert.Equal(3.0m, repo.Prices["chilling flux"].DivineValue);
+    }
+
+    // Malformed custom_prices.json must not crash the app — the error is logged and the
+    // poe.ninja prices are kept as-is.
+    [Fact]
+    public async Task CustomOverride_MalformedJson_IsIgnoredSilently()
+    {
+        using var http = FakeHttp(FakeApiResponse);
+        using var dir = new TempDir();
+        File.WriteAllText(Path.Combine(dir.Path, "custom_prices.json"), "{ not valid json !!!");
+
+        var repo = new PriceRepository(http);
+        await repo.InitialFetchAsync(DefaultConfig(dir.Path));
+
+        // poe.ninja data survives the bad override file.
+        Assert.True(repo.Prices.ContainsKey("chilling flux"));
+        Assert.Equal(0.5m, repo.Prices["chilling flux"].DivineValue);
+    }
+
+    // A response missing the `core` block (e.g. an API change or network truncation) should
+    // not throw — it degrades to showing zero prices rather than crashing.
+    [Fact]
+    public async Task MissingCoreBlock_DoesNotThrow()
+    {
+        const string response = """
+            {
+              "items": [{ "id": "chilling-flux", "name": "Chilling Flux" }],
+              "lines": [{ "id": "chilling-flux", "primaryValue": 0.5 }]
+            }
+            """;
+
+        using var http = FakeHttp(response);
+        using var dir = new TempDir();
+        var repo = new PriceRepository(http);
+        var ex = await Record.ExceptionAsync(() => repo.InitialFetchAsync(DefaultConfig(dir.Path)));
+        Assert.Null(ex);
+    }
+
     [Theory]
     [InlineData("Support: Scattering Flame", "support scattering flame")]
     [InlineData("CHILLING FLUX", "chilling flux")]


### PR DESCRIPTION
## Summary

Four code paths in `ParseResponse` and `ApplyCustomOverride` had no test coverage:

- **`NullPrimaryValue_SetsHasMarketDataFalse`** — items with `"primaryValue": null` in the poe.ninja response should be stored with `HasMarketData: false` so the overlay can show a "no info" row rather than silently dropping the item. The code path exists but was untested.
- **`CustomOverride_AcceptsUnnormalizedKey`** — `ApplyCustomOverride` runs keys through `NameNormalizer`, so `"Chilling Flux"` in `custom_prices.json` should work identically to `"chilling flux"`. Users writing the file manually are more likely to use display names, so this behaviour is worth pinning.
- **`CustomOverride_MalformedJson_IsIgnoredSilently`** — a broken override file should log and leave poe.ninja prices intact, not crash. The try/catch is there but had no test.
- **`MissingCoreBlock_DoesNotThrow`** — a truncated or malformed API response missing the `core` block should degrade gracefully (zeroed prices) rather than throw.

No production code was changed.

## Test plan

- [ ] `dotnet test src/PoeAncientsPriceHelper.Tests/` on Windows passes with all 4 new tests green
- [ ] Existing tests remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)