### PR TITLE
QoL: auto-start, Settings window, resilient price fetching

### DIFF
--- a/src/PoeAncientsPriceHelper/App.xaml.cs
+++ b/src/PoeAncientsPriceHelper/App.xaml.cs
@@ -218,6 +218,35 @@ public partial class App : System.Windows.Application
         catch { /* best-effort focus; the guard still prevents the second instance */ }
     }
 
+    // Relaunch with --debug so a user can capture diagnostics (scan_log.txt / debug_ocr.png) for a bug
+    // report — the old debug.cmd no longer ships with the Velopack build, so this is the only in-app way
+    // to turn logging on. The single-instance mutex is released first, on the UI thread that created it
+    // (the same thread as the caller), so the relaunched copy can take it; otherwise it would treat us as
+    // the running instance, focus our window, and exit — leaving nothing running. If the spawn fails we
+    // re-acquire the mutex so the guard is restored and the still-running app stays single-instance.
+    // Returns false if the exe path is unknown or the process failed to start.
+    internal static bool RelaunchWithDebug()
+    {
+        var exe = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exe)) return false;
+
+        try { _instanceMutex?.ReleaseMutex(); } catch { /* not owned / already released */ }
+        _instanceMutex?.Dispose();
+        _instanceMutex = null;
+
+        try
+        {
+            Process.Start(new ProcessStartInfo(exe, "--debug") { UseShellExecute = true });
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Diagnostics] relaunch with --debug failed: {ex.Message}");
+            _instanceMutex = new Mutex(initiallyOwned: true, InstanceMutexName, out _);   // restore the guard
+            return false;
+        }
+    }
+
     private static void RunOcrTest(string imagePath)
     {
         var outPath = System.IO.Path.Combine(AppPaths.DataDir, "ocr_test.txt");

--- a/src/PoeAncientsPriceHelper/AppConfig.cs
+++ b/src/PoeAncientsPriceHelper/AppConfig.cs
@@ -29,6 +29,10 @@ internal sealed class AppConfig
     public string CaptureBackend { get; set; } = "Auto";
     // UI theme preset name. Default "Toxic" (dark green gradient).
     public string Theme { get; set; } = "Toxic";
+    // When true (and a region is calibrated), launching the app auto-starts scanning and minimizes to
+    // the tray — "just open it and it runs". Missing in older configs → true (the new default behaviour).
+    // Skipped under --debug so a troubleshooting session keeps the window and console visible.
+    public bool AutoStart { get; set; } = true;
 
     public Rectangle RegionRect
     {

--- a/src/PoeAncientsPriceHelper/MainWindow.xaml
+++ b/src/PoeAncientsPriceHelper/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-        Title="Poe Ancients Price Helper" Height="410" Width="500"
+        Title="Poe Ancients Price Helper" Height="340" Width="500"
         Icon="app.ico"
         ResizeMode="CanMinimize"
         WindowStartupLocation="CenterScreen"
@@ -62,8 +62,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -73,61 +71,41 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
-        <TextBlock Grid.Row="0" Grid.Column="0" Text="League:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
-        <ComboBox Grid.Row="0" Grid.Column="1" x:Name="LeagueBox" Margin="0,4" SelectionChanged="LeagueBox_SelectionChanged"/>
+        <!-- Header: gear opens the Settings window (keybinds, theme, capture mode, auto-start). -->
+        <Button Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                x:Name="SettingsButton" Style="{StaticResource FlatButton}"
+                Content="⚙" FontSize="15"
+                HorizontalAlignment="Right" VerticalAlignment="Top"
+                Padding="8,2" Margin="0,0,0,4"
+                Background="#2A2A2A" Foreground="#CCC" BorderBrush="#444"
+                ToolTip="Settings — hotkeys, theme, capture mode, auto-start"
+                Click="SettingsButton_Click"/>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Text="Region:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
-        <TextBlock Grid.Row="1" Grid.Column="1" x:Name="RegionLabel" Text="Not calibrated" Foreground="#666" FontFamily="Consolas" FontSize="11" VerticalAlignment="Center"/>
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="League:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
+        <ComboBox Grid.Row="1" Grid.Column="1" x:Name="LeagueBox" Margin="0,4" SelectionChanged="LeagueBox_SelectionChanged"/>
 
-        <TextBlock Grid.Row="2" Grid.Column="0" Text="Start/Stop key:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
-        <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,4">
-            <TextBlock x:Name="HotkeyLabel" Text="F5" VerticalAlignment="Center"
-                       FontFamily="Consolas" FontSize="12" MinWidth="46"/>
-            <Button x:Name="RebindButton" Content="Rebind" Style="{StaticResource FlatButton}"
-                    Background="#2A2A2A" Foreground="#CCC" BorderBrush="#444"
-                    FontSize="11" Padding="10,2"
-                    Click="RebindButton_Click"/>
-        </StackPanel>
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Region:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
+        <TextBlock Grid.Row="2" Grid.Column="1" x:Name="RegionLabel" Text="Not calibrated" Foreground="#666" FontFamily="Consolas" FontSize="11" VerticalAlignment="Center"/>
 
-        <TextBlock Grid.Row="3" Grid.Column="0" Text="Debug overlay key:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
-        <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal" Margin="0,4">
-            <TextBlock x:Name="DebugHotkeyLabel" Text="F3" VerticalAlignment="Center"
-                       FontFamily="Consolas" FontSize="12" MinWidth="46"/>
-            <Button x:Name="RebindDebugButton" Content="Rebind" Style="{StaticResource FlatButton}"
-                    Background="#2A2A2A" Foreground="#CCC" BorderBrush="#444"
-                    FontSize="11" Padding="10,2"
-                    Click="RebindDebugButton_Click"/>
-        </StackPanel>
-
-        <TextBlock Grid.Row="4" Grid.Column="0" Text="Calibrate key:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
-        <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal" Margin="0,4">
-            <TextBlock x:Name="CalibrateHotkeyLabel" Text="F4" VerticalAlignment="Center"
-                       FontFamily="Consolas" FontSize="12" MinWidth="46"/>
-            <Button x:Name="RebindCalibrateButton" Content="Rebind" Style="{StaticResource FlatButton}"
-                    Background="#2A2A2A" Foreground="#CCC" BorderBrush="#444"
-                    FontSize="11" Padding="10,2"
-                    Click="RebindCalibrateButton_Click"/>
-        </StackPanel>
-
-        <Button Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
+        <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"
                 x:Name="CalibrateButton" Style="{StaticResource FlatButton}"
                 Content="Calibrate Region" Margin="0,10,0,0"
                 Background="#1A2A3A" Foreground="#66AAFF" BorderBrush="#336699"
                 Click="CalibrateButton_Click"/>
 
-        <TextBlock Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2"
+        <TextBlock Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2"
                    x:Name="StatusLabel"
                    Text="Idle — prices not loaded"
                    Foreground="#666" FontSize="11" Margin="0,10,0,0"/>
 
-        <Button Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
+        <Button Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2"
                 x:Name="StartStopButton" Style="{StaticResource FlatButton}"
                 Content="Start" IsEnabled="False"
                 Margin="0,10,0,0"
                 Background="#1A3A1A" Foreground="#66FF66" BorderBrush="#337733"
                 Click="StartStopButton_Click"/>
 
-        <StackPanel Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2"
+        <StackPanel Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
                     HorizontalAlignment="Left" VerticalAlignment="Bottom"
                     Orientation="Horizontal">
             <TextBlock x:Name="VersionLabel"
@@ -146,17 +124,12 @@
                        Cursor="Hand" TextDecorations="Underline" Margin="6,0,0,0"
                        ToolTip="Restart with logging enabled to capture a report for a bug"
                        MouseLeftButtonUp="DiagnosticsLink_Click"/>
-            <StackPanel Orientation="Vertical" Margin="12,0,0,0">
-                <TextBlock Text="Theme" Foreground="#999" FontSize="11" Margin="0,0,0,2"/>
-                <ComboBox x:Name="ThemeBox" FontSize="11" MinWidth="90"
-                          SelectionChanged="ThemeBox_SelectionChanged"/>
-            </StackPanel>
         </StackPanel>
 
         <!-- The update notice gets its own row directly above the bottom bar so its (variable-length)
-             text can never overlap the theme dropdown or the donate button. Collapsed when up to date,
-             and Row 9 is Auto, so it takes no space until an update is actually staged. -->
-        <TextBlock Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2"
+             text can never overlap the donate button. Collapsed when up to date, and Row 7 is Auto, so
+             it takes no space until an update is actually staged. -->
+        <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2"
                    x:Name="UpdateLink"
                    HorizontalAlignment="Center" VerticalAlignment="Center"
                    TextAlignment="Center" Margin="0,0,0,8"
@@ -164,7 +137,7 @@
                    Cursor="Hand" Visibility="Collapsed" TextDecorations="Underline"
                    MouseLeftButtonUp="UpdateLink_Click"/>
 
-        <Button Grid.Row="10" Grid.Column="0" Grid.ColumnSpan="2"
+        <Button Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
                 x:Name="DonateButton" Style="{StaticResource FlatButton}"
                 Content="☕ Buy me a coffee"
                 HorizontalAlignment="Right" VerticalAlignment="Bottom"

--- a/src/PoeAncientsPriceHelper/MainWindow.xaml
+++ b/src/PoeAncientsPriceHelper/MainWindow.xaml
@@ -139,6 +139,13 @@
                        Cursor="Hand" TextDecorations="Underline" Margin="6,0,0,0"
                        ToolTip="Thanks to the people who contributed"
                        MouseLeftButtonUp="CreditsLink_Click"/>
+            <TextBlock Text="·" Foreground="#666" FontSize="11"
+                       VerticalAlignment="Bottom" Margin="6,0,0,0"/>
+            <TextBlock x:Name="DiagnosticsLink" Text="Diagnostics"
+                       Foreground="#999" FontSize="11" VerticalAlignment="Bottom"
+                       Cursor="Hand" TextDecorations="Underline" Margin="6,0,0,0"
+                       ToolTip="Restart with logging enabled to capture a report for a bug"
+                       MouseLeftButtonUp="DiagnosticsLink_Click"/>
             <StackPanel Orientation="Vertical" Margin="12,0,0,0">
                 <TextBlock Text="Theme" Foreground="#999" FontSize="11" Margin="0,0,0,2"/>
                 <ComboBox x:Name="ThemeBox" FontSize="11" MinWidth="90"

--- a/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
+++ b/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
@@ -84,6 +84,14 @@ public partial class MainWindow : Window
     {
         _config = ConfigStore.Load();
         PopulateFields();
+        // When already running in debug mode the relaunch is pointless — repurpose the link to open the
+        // folder the logs land in. App.DebugMode is settled by now (it's set in App.OnStartup, before the
+        // window's Loaded fires).
+        if (App.DebugMode)
+        {
+            DiagnosticsLink.Text = "Open logs";
+            DiagnosticsLink.ToolTip = "Open the folder with scan_log.txt and debug_ocr.png";
+        }
         await StartupAsync();
         // Fire-and-forget, once per launch (not inside StartupAsync, which re-runs on league change).
         // A slow/hung GitHub response must never delay the price fetch or the Start button.
@@ -174,6 +182,43 @@ public partial class MainWindow : Window
     }
 
     private void UpdateLink_Click(object sender, System.Windows.Input.MouseButtonEventArgs e) => ApplyUpdateNow();
+
+    // "Diagnostics" link. In a normal run it offers to restart with --debug so the user can capture
+    // scan_log.txt / debug_ocr.png for a bug report (the old debug.cmd no longer ships with the Velopack
+    // build). When already running in debug mode it instead opens the folder those files land in.
+    private void DiagnosticsLink_Click(object sender, System.Windows.Input.MouseButtonEventArgs e)
+    {
+        if (App.DebugMode) { OpenDataFolder(); return; }
+
+        var choice = System.Windows.MessageBox.Show(this,
+            "Restart with diagnostics logging enabled?\n\n" +
+            "A console window will open and detailed logs (scan_log.txt and debug_ocr.png) will be " +
+            "written to your data folder so you can attach them to a bug report.\n\n" +
+            "The app will close and reopen now.",
+            "Diagnostics", System.Windows.MessageBoxButton.OKCancel, System.Windows.MessageBoxImage.Question);
+        if (choice != System.Windows.MessageBoxResult.OK) return;
+
+        if (App.RelaunchWithDebug())
+            Close();   // routes through Window_Closing for a clean shutdown; the new --debug copy takes over
+        else
+            System.Windows.MessageBox.Show(this,
+                "Couldn't restart in diagnostics mode. You can launch the app from a terminal with the " +
+                "--debug switch instead.",
+                "Diagnostics", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Warning);
+    }
+
+    private void OpenDataFolder()
+    {
+        try
+        {
+            System.Diagnostics.Process.Start(
+                new System.Diagnostics.ProcessStartInfo(AppPaths.DataDir) { UseShellExecute = true });
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Diagnostics] open data folder failed: {ex.Message}");
+        }
+    }
 
     // Apply the already-staged update and relaunch into the new version. Invoked by the "Update now"
     // link, and by the POEPRICE_TEST_UPDATE_NOW test seam so the relaunch path is exercised directly.

--- a/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
+++ b/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
@@ -66,6 +66,16 @@ public partial class MainWindow : Window
             DiagnosticsLink.ToolTip = "Open the folder with scan_log.txt and debug_ocr.png";
         }
         await StartupAsync();
+        // Auto-start QoL: with a calibrated region and the option enabled, begin scanning and drop
+        // straight to the tray, so the user just opens the app and it runs (saving the Start + minimize
+        // clicks). Skipped under --debug (keep the window and console visible for troubleshooting) and
+        // when not calibrated (the user has to calibrate first, so the window must stay up for input).
+        // _engine is null here on a fresh load (StartupAsync only restarts it across a league change).
+        if (_config.AutoStart && _config.IsCalibrated && !App.DebugMode && _engine is null)
+        {
+            ToggleStartStop();                     // start the engine; flips the button to Stop
+            WindowState = WindowState.Minimized;   // OnStateChanged hides to tray + shows the balloon once
+        }
         // Fire-and-forget, once per launch (not inside StartupAsync, which re-runs on league change).
         // A slow/hung GitHub response must never delay the price fetch or the Start button.
         _ = CheckForUpdatesAsync();

--- a/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
+++ b/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
@@ -10,33 +10,6 @@ namespace PoeAncientsPriceHelper;
 
 public partial class MainWindow : Window
 {
-    // Dark theme presets. Only the window background changes — button colors are hardcoded in
-    // FlatButton and are never affected by theme switches.
-    private static readonly (string Name, System.Windows.Media.Brush Background)[] Themes =
-    [
-        ("Midnight", CreateSolid(0x1C, 0x1C, 0x1C)),
-        ("Obsidian", CreateGradient(0x05, 0x05, 0x05, 0x14, 0x14, 0x14)),
-        ("Abyss",    CreateGradient(0x0A, 0x0F, 0x1E, 0x0D, 0x15, 0x28)),
-        ("Ember",    CreateGradient(0x1A, 0x0F, 0x08, 0x0F, 0x08, 0x05)),
-        ("Toxic",    CreateGradient(0x0A, 0x12, 0x08, 0x0D, 0x1A, 0x0A)),
-    ];
-
-    private static System.Windows.Media.Brush CreateSolid(byte r, byte g, byte b)
-    {
-        var brush = new SolidColorBrush(System.Windows.Media.Color.FromRgb(r, g, b));
-        brush.Freeze();
-        return brush;
-    }
-
-    private static System.Windows.Media.Brush CreateGradient(byte r1, byte g1, byte b1, byte r2, byte g2, byte b2)
-    {
-        var brush = new LinearGradientBrush(
-            System.Windows.Media.Color.FromRgb(r1, g1, b1),
-            System.Windows.Media.Color.FromRgb(r2, g2, b2), 90);
-        brush.Freeze();
-        return brush;
-    }
-
     private AppConfig _config = new();
     private PriceRepository? _repo;
     private IconCache? _icons;
@@ -244,43 +217,21 @@ public partial class MainWindow : Window
         LeagueBox.SelectedItem = _config.AvailableLeagues.Contains(_config.LeagueName)
             ? _config.LeagueName
             : _config.AvailableLeagues.FirstOrDefault();
-        // Arm the global hook with all three persisted bindings and mirror them into the labels.
-        var startStop = HotkeyBinding.Parse(_config.StartStopHotkey);
-        var debug = HotkeyBinding.Parse(_config.DebugHotkey);
-        var calibrate = HotkeyBinding.Parse(_config.CalibrateHotkey);
-        HotkeyLabel.Text = HotkeyBinding.Display(startStop);
-        DebugHotkeyLabel.Text = HotkeyBinding.Display(debug);
-        CalibrateHotkeyLabel.Text = HotkeyBinding.Display(calibrate);
-        App.SetStartStopKey(startStop);
-        App.SetDebugKey(debug);
-        App.SetCalibrateKey(calibrate);
+        // Arm the global hook with all three persisted bindings. The keybind UI lives in the Settings
+        // window now, but the hook must be armed at startup so the hotkeys work before it's ever opened.
+        App.SetStartStopKey(HotkeyBinding.Parse(_config.StartStopHotkey));
+        App.SetDebugKey(HotkeyBinding.Parse(_config.DebugHotkey));
+        App.SetCalibrateKey(HotkeyBinding.Parse(_config.CalibrateHotkey));
         UpdateRegionLabel();
-        PopulateThemeBox();
+        ThemePresets.Apply(ThemePresets.Resolve(_config.Theme));
         _loading = false;
     }
 
-    private void PopulateThemeBox()
-    {
-        ThemeBox.ItemsSource = Themes.Select(t => t.Name).ToArray();
-        var saved = Themes.Any(t => t.Name == _config.Theme) ? _config.Theme : "Toxic";
-        ThemeBox.SelectedItem = saved;
-        ApplyTheme(saved);
-    }
-
-    private void ApplyTheme(string name)
-    {
-        var preset = Array.Find(Themes, t => t.Name == name);
-        if (preset.Name is null) return;
-        Resources["ApplicationBackgroundBrush"] = preset.Background;
-    }
-
-    private void ThemeBox_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
-    {
-        if (_loading || ThemeBox.SelectedItem is not string theme) return;
-        _config.Theme = theme;
-        ConfigStore.Save(_config);
-        ApplyTheme(theme);
-    }
+    // Opens the modal Settings window. It edits the same _config instance and persists each change, so
+    // nothing needs syncing back here: theme is applied app-wide live, hotkey rebinds re-arm the hook,
+    // and capture/auto-start are read straight from _config when next needed.
+    private void SettingsButton_Click(object sender, RoutedEventArgs e) =>
+        new SettingsWindow(_config) { Owner = this }.ShowDialog();
 
     private void UpdateRegionLabel()
     {
@@ -498,80 +449,4 @@ public partial class MainWindow : Window
         }
     }
 
-    // The rebind in progress: which action, and the button/label to update. Only one runs at a time.
-    private HotkeyBinding.Action _rebindAction;
-    private System.Windows.Controls.Button? _rebindButton;
-    private System.Windows.Controls.TextBlock? _rebindLabel;
-
-    private void RebindButton_Click(object sender, RoutedEventArgs e) =>
-        BeginRebind(HotkeyBinding.Action.StartStop, RebindButton, HotkeyLabel);
-
-    private void RebindDebugButton_Click(object sender, RoutedEventArgs e) =>
-        BeginRebind(HotkeyBinding.Action.Debug, RebindDebugButton, DebugHotkeyLabel);
-
-    private void RebindCalibrateButton_Click(object sender, RoutedEventArgs e) =>
-        BeginRebind(HotkeyBinding.Action.Calibrate, RebindCalibrateButton, CalibrateHotkeyLabel);
-
-    private void BeginRebind(HotkeyBinding.Action action, System.Windows.Controls.Button button,
-                             System.Windows.Controls.TextBlock label)
-    {
-        _rebindAction = action;
-        _rebindButton = button;
-        _rebindLabel = label;
-        // Disable all three rebind buttons so a second capture can't start mid-rebind.
-        SetRebindButtonsEnabled(false);
-        button.Content = "Press a key… (Esc to cancel)";
-        App.BeginHotkeyCapture(action, OnHotkeyCaptured);   // outcome arrives on the UI thread
-    }
-
-    // Invoked (marshalled to the UI thread) when the global hook resolves a rebind capture.
-    private void OnHotkeyCaptured(App.CaptureOutcome outcome, KeyCode code)
-    {
-        switch (outcome)
-        {
-            case App.CaptureOutcome.Captured:
-                switch (_rebindAction)
-                {
-                    case HotkeyBinding.Action.StartStop:
-                        _config.StartStopHotkey = HotkeyBinding.ToStorage(code);
-                        App.SetStartStopKey(code);
-                        break;
-                    case HotkeyBinding.Action.Debug:
-                        _config.DebugHotkey = HotkeyBinding.ToStorage(code);
-                        App.SetDebugKey(code);
-                        break;
-                    case HotkeyBinding.Action.Calibrate:
-                        _config.CalibrateHotkey = HotkeyBinding.ToStorage(code);
-                        App.SetCalibrateKey(code);
-                        break;
-                }
-                ConfigStore.Save(_config);
-                if (_rebindLabel is not null) _rebindLabel.Text = HotkeyBinding.Display(code);
-                EndRebind();
-                break;
-            case App.CaptureOutcome.Reserved:
-                // Still listening — tell the user why that key won't take, keep the prompt up.
-                if (_rebindButton is not null)
-                    _rebindButton.Content = $"{HotkeyBinding.Display(code)} is in use — try another";
-                break;
-            case App.CaptureOutcome.Cancelled:
-                EndRebind();
-                break;
-        }
-    }
-
-    private void EndRebind()
-    {
-        if (_rebindButton is not null) _rebindButton.Content = "Rebind";
-        _rebindButton = null;
-        _rebindLabel = null;
-        SetRebindButtonsEnabled(true);
-    }
-
-    private void SetRebindButtonsEnabled(bool enabled)
-    {
-        RebindButton.IsEnabled = enabled;
-        RebindDebugButton.IsEnabled = enabled;
-        RebindCalibrateButton.IsEnabled = enabled;
-    }
 }

--- a/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
+++ b/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
@@ -271,6 +271,7 @@ public partial class MainWindow : Window
 
         _repo = new PriceRepository(_http);
         _repo.PricesUpdated += OnPricesUpdated;   // keep the "last fetch" label live on each refresh
+        _repo.FetchFailed += OnFetchFailed;       // flag a failed fetch (red/amber) in the status label
         _icons = new IconCache(_http);
 
         await Task.WhenAll(
@@ -310,11 +311,56 @@ public partial class MainWindow : Window
         _ = CheckForUpdatesAsync();
     }
 
+    // Status-label colors: normal (matches the XAML default), amber when a refresh failed but prices
+    // from an earlier fetch are still showing, red when no prices have ever loaded.
+    private static readonly System.Windows.Media.Brush StatusNormalBrush = FrozenBrush(0x66, 0x66, 0x66);
+    private static readonly System.Windows.Media.Brush StatusStaleBrush = FrozenBrush(0xE0, 0xB0, 0x60);
+    private static readonly System.Windows.Media.Brush StatusFailBrush = FrozenBrush(0xFF, 0x55, 0x55);
+
+    private static System.Windows.Media.Brush FrozenBrush(byte r, byte g, byte b)
+    {
+        var brush = new System.Windows.Media.SolidColorBrush(System.Windows.Media.Color.FromRgb(r, g, b));
+        brush.Freeze();
+        return brush;
+    }
+
     private void UpdateStatusLabel()
     {
         if (_repo is null) return;
+        // Called after a fetch completes (initial load + each successful refresh). If we still have no
+        // prices, the fetch failed — show the red state (the repo is retrying every 30s) rather than a
+        // misleading "0 items loaded". This also avoids a successful-path call clobbering the failure.
+        if (_repo.ItemCount == 0)
+        {
+            StatusLabel.Foreground = StatusFailBrush;
+            StatusLabel.Text = "Failed to get prices from poe.ninja — retrying…";
+            return;
+        }
         string fetched = _repo.LastFetchedAt is { } t ? t.ToString("MMM d HH:mm") : "never";
+        StatusLabel.Foreground = StatusNormalBrush;
         StatusLabel.Text = $"{_repo.ItemCount} items loaded  ·  last fetch {fetched}";
+    }
+
+    // A fetch failed (network error or 0 items). Prices already loaded from a prior fetch are kept, so
+    // distinguish "couldn't refresh, still showing the last set" (amber) from "never got any" (red).
+    // The repository retries every 30s until it succeeds, when OnPricesUpdated restores the normal label.
+    private void OnFetchFailed()
+    {
+        Dispatcher.BeginInvoke(() =>
+        {
+            if (_repo is null) return;
+            if (_repo.ItemCount > 0)
+            {
+                string t = _repo.LastFetchedAt is { } at ? at.ToString("MMM d HH:mm") : "earlier";
+                StatusLabel.Foreground = StatusStaleBrush;
+                StatusLabel.Text = $"Couldn't refresh — retrying (showing last fetch {t})";
+            }
+            else
+            {
+                StatusLabel.Foreground = StatusFailBrush;
+                StatusLabel.Text = "Failed to get prices from poe.ninja — retrying…";
+            }
+        });
     }
 
     private void DonateButton_Click(object sender, RoutedEventArgs e)

--- a/src/PoeAncientsPriceHelper/PriceRepository.cs
+++ b/src/PoeAncientsPriceHelper/PriceRepository.cs
@@ -29,6 +29,13 @@ internal sealed class PriceRepository : IDisposable
     private readonly CancellationTokenSource _cts = new();
     private int _priceGeneration;
 
+    // Adaptive refresh cadence: normally every 30 min, but after a failed fetch (0 usable items) the
+    // timer re-arms every 30s until prices come back — so a launch/refresh that hit a transient
+    // poe.ninja outage recovers in seconds instead of being stuck behind the full 30-min interval.
+    private static readonly TimeSpan NormalInterval = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan RetryInterval = TimeSpan.FromSeconds(30);
+    private AppConfig? _refreshConfig;
+
     public PriceSnapshot Current => _snapshot;
     public IReadOnlyDictionary<string, PriceEntry> Prices => _snapshot.Prices;
     // Snapshot of the length-bucketed key index, for the fuzzy matcher in ScanEngine.
@@ -38,10 +45,16 @@ internal sealed class PriceRepository : IDisposable
     // Bumped each time _prices is replaced; ScanEngine uses it to invalidate its resolution cache.
     public int PriceGeneration => Volatile.Read(ref _priceGeneration);
 
-    // Raised after every successful fetch (initial + each 30-min background refresh) so the UI can
-    // refresh its "last fetch" label — which otherwise stays frozen at the startup time. Fires on a
+    // Raised after every successful fetch (initial + each background refresh) so the UI can refresh
+    // its "last fetch" label — which otherwise stays frozen at the startup time. Fires on a
     // thread-pool thread; subscribers must marshal to the UI thread.
     public event Action? PricesUpdated;
+
+    // Raised when a fetch fails (a network exception, or every request came back empty so we ended up
+    // with 0 usable items). The previous good snapshot is kept, not overwritten — so the overlay keeps
+    // showing the last prices — and the UI can flag the failure (ItemCount/LastFetchedAt tell it
+    // whether any prices were ever loaded). Not raised on shutdown cancellation. Fires off the UI thread.
+    public event Action? FetchFailed;
 
     // Only the 5 exchange categories whose items actually appear as Verisium Remnant rewards.
     // Other poe.ninja categories (Essences, SoulCores, Idols, Omens, Catalysts, etc.) belong to
@@ -58,12 +71,30 @@ internal sealed class PriceRepository : IDisposable
 
     public void StartAutoRefresh(AppConfig config)
     {
+        _refreshConfig = config;
         _timer?.Dispose();
-        _timer = new System.Threading.Timer(_ => Task.Run(() => FetchAndMergeAsync(config, _cts.Token)),
-            null, TimeSpan.FromMinutes(30), TimeSpan.FromMinutes(30));
+        // Self-rescheduling (period = Infinite): each tick re-arms based on its own outcome, so the
+        // cadence adapts between 30 min (healthy) and 30s (retrying). The first delay reflects the
+        // initial fetch already done in InitialFetchAsync — retry fast if it produced nothing.
+        _timer = new System.Threading.Timer(RefreshTick, null,
+            ItemCount == 0 ? RetryInterval : NormalInterval, Timeout.InfiniteTimeSpan);
     }
 
-    private async Task FetchAndMergeAsync(AppConfig config, CancellationToken ct)
+    // Timer callback (async void is fine here: FetchAndMergeAsync swallows its own exceptions and
+    // never throws). Re-arms the one-shot timer to the next interval based on whether prices loaded.
+    private async void RefreshTick(object? _)
+    {
+        if (_cts.IsCancellationRequested) return;
+        bool ok = await FetchAndMergeAsync(_refreshConfig!, _cts.Token);
+        try { _timer?.Change(ok ? NormalInterval : RetryInterval, Timeout.InfiniteTimeSpan); }
+        catch (ObjectDisposedException) { /* disposed during shutdown — nothing to re-arm */ }
+    }
+
+    // Returns true if the fetch published at least one usable price. On failure (a network exception
+    // or 0 items) the previous good snapshot is left in place — a transient outage must not blank the
+    // overlay — and FetchFailed is raised so the UI can flag it. Shutdown cancellation returns false
+    // quietly (no event).
+    private async Task<bool> FetchAndMergeAsync(AppConfig config, CancellationToken ct)
     {
         try
         {
@@ -77,6 +108,16 @@ internal sealed class PriceRepository : IDisposable
                 foreach (var (name, entry) in entries)
                     dict[name] = entry;
             ApplyCustomOverride(dict, config.CustomPricesPath);
+
+            // Every request came back empty (poe.ninja down/blocking, bad league, etc.). Keep the last
+            // good snapshot so the overlay stays useful, flag the failure, and let the caller retry soon.
+            if (dict.Count == 0)
+            {
+                Console.Error.WriteLine("[PriceRepository] fetch produced 0 items — keeping last prices");
+                FetchFailed?.Invoke();
+                return false;
+            }
+
             var keysByLength = dict.Keys.GroupBy(k => k.Length).ToDictionary(g => g.Key, g => g.ToList());
             // Publish both atomically in a single volatile write so the scan loop never sees
             // a new Prices with a stale KeysByLength (or vice versa).
@@ -86,15 +127,19 @@ internal sealed class PriceRepository : IDisposable
             Interlocked.Increment(ref _priceGeneration);
             LastFetchedAt = DateTime.Now;
             PricesUpdated?.Invoke();
+            return true;
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             // Shutting down — abandon this cycle quietly. (A timeout, by contrast, is not
-            // cancellation-requested, so it falls through to the log below.)
+            // cancellation-requested, so it falls through to the failure handling below.)
+            return false;
         }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[PriceRepository] fetch failed: {ex.Message}");
+            FetchFailed?.Invoke();
+            return false;
         }
     }
 

--- a/src/PoeAncientsPriceHelper/SettingsWindow.xaml
+++ b/src/PoeAncientsPriceHelper/SettingsWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="PoeAncientsPriceHelper.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Settings" Height="320" Width="380"
+        Title="Settings" Height="400" Width="380"
         Icon="app.ico"
         ResizeMode="NoResize"
         ShowInTaskbar="False"

--- a/src/PoeAncientsPriceHelper/SettingsWindow.xaml
+++ b/src/PoeAncientsPriceHelper/SettingsWindow.xaml
@@ -1,0 +1,119 @@
+<Window x:Class="PoeAncientsPriceHelper.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings" Height="320" Width="380"
+        Icon="app.ico"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource ApplicationBackgroundBrush}"
+        Foreground="{DynamicResource TextFillColorPrimaryBrush}">
+
+    <Window.Resources>
+        <Style x:Key="FieldLabel" TargetType="TextBlock">
+            <Setter Property="Foreground" Value="#999"/>
+            <Setter Property="FontSize" Value="11"/>
+            <Setter Property="Margin" Value="0,6,0,2"/>
+        </Style>
+
+        <!-- Same flat button used on the main window: a TemplateBinding template so local
+             Background/Foreground/BorderBrush always apply (WPF UI's implicit style ignores them). -->
+        <Style x:Key="FlatButton" TargetType="Button">
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="Padding" Value="12,6"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="4"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
+                                              TextBlock.FontSize="{TemplateBinding FontSize}"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style.Triggers>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter Property="Opacity" Value="0.35"/>
+                </Trigger>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Opacity" Value="0.82"/>
+                </Trigger>
+                <Trigger Property="IsPressed" Value="True">
+                    <Setter Property="Opacity" Value="0.68"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="20,16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="140"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"
+                   Text="Settings" FontSize="18" FontWeight="SemiBold" Margin="0,0,0,10"/>
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="Start/Stop key:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Horizontal" Margin="0,4">
+            <TextBlock x:Name="HotkeyLabel" Text="F5" VerticalAlignment="Center"
+                       FontFamily="Consolas" FontSize="12" MinWidth="46"/>
+            <Button x:Name="RebindButton" Content="Rebind" Style="{StaticResource FlatButton}"
+                    Background="#2A2A2A" Foreground="#CCC" BorderBrush="#444"
+                    FontSize="11" Padding="10,2" Click="RebindButton_Click"/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="Debug overlay key:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="2" Grid.Column="1" Orientation="Horizontal" Margin="0,4">
+            <TextBlock x:Name="DebugHotkeyLabel" Text="F3" VerticalAlignment="Center"
+                       FontFamily="Consolas" FontSize="12" MinWidth="46"/>
+            <Button x:Name="RebindDebugButton" Content="Rebind" Style="{StaticResource FlatButton}"
+                    Background="#2A2A2A" Foreground="#CCC" BorderBrush="#444"
+                    FontSize="11" Padding="10,2" Click="RebindDebugButton_Click"/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="Calibrate key:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal" Margin="0,4">
+            <TextBlock x:Name="CalibrateHotkeyLabel" Text="F4" VerticalAlignment="Center"
+                       FontFamily="Consolas" FontSize="12" MinWidth="46"/>
+            <Button x:Name="RebindCalibrateButton" Content="Rebind" Style="{StaticResource FlatButton}"
+                    Background="#2A2A2A" Foreground="#CCC" BorderBrush="#444"
+                    FontSize="11" Padding="10,2" Click="RebindCalibrateButton_Click"/>
+        </StackPanel>
+
+        <TextBlock Grid.Row="4" Grid.Column="0" Text="Theme:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
+        <ComboBox Grid.Row="4" Grid.Column="1" x:Name="ThemeBox" Margin="0,4" MinWidth="120"
+                  HorizontalAlignment="Left" SelectionChanged="ThemeBox_SelectionChanged"/>
+
+        <TextBlock Grid.Row="5" Grid.Column="0" Text="Capture mode:" Style="{StaticResource FieldLabel}" VerticalAlignment="Center"/>
+        <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Vertical" Margin="0,4">
+            <ComboBox x:Name="CaptureBox" MinWidth="160" HorizontalAlignment="Left"
+                      SelectionChanged="CaptureBox_SelectionChanged"/>
+            <TextBlock Text="(applies on next start)" Foreground="#666" FontSize="10" Margin="0,2,0,0"/>
+        </StackPanel>
+
+        <CheckBox Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" x:Name="AutoStartBox"
+                  Margin="0,12,0,0" Foreground="#CCC" FontSize="12"
+                  Content="Auto-start scanning and minimize to tray on launch"
+                  Checked="AutoStartBox_Changed" Unchecked="AutoStartBox_Changed"/>
+        <TextBlock Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Top"
+                   Text="Only applies once a region is calibrated. Just open the app and it starts in the tray."
+                   Foreground="#666" FontSize="10" TextWrapping="Wrap" Margin="0,4,0,0"/>
+    </Grid>
+</Window>

--- a/src/PoeAncientsPriceHelper/SettingsWindow.xaml.cs
+++ b/src/PoeAncientsPriceHelper/SettingsWindow.xaml.cs
@@ -1,0 +1,154 @@
+using System.Windows;
+using System.Windows.Controls;
+using SharpHook.Data;
+// WinForms is referenced (tray icon), so Button is ambiguous — pin it to the WPF control.
+using Button = System.Windows.Controls.Button;
+
+namespace PoeAncientsPriceHelper;
+
+// Modal settings dialog opened from the gear button on MainWindow. Holds the controls that used to
+// clutter the main window (the three hotkey rebinds and the theme picker) plus two new options:
+// the capture backend and auto-start. It mutates the SAME AppConfig instance the main window holds
+// (passed in), so changes are visible there immediately; every change persists on the spot via
+// ConfigStore.Save — there is no OK/Cancel, just close. Hotkey changes also re-arm the live global
+// hook through App; theme changes apply app-wide via ThemePresets so both windows update live.
+public partial class SettingsWindow : Window
+{
+    private readonly AppConfig _config;
+    private bool _loading;
+
+    // internal: takes the internal AppConfig and is only ever constructed from MainWindow.
+    internal SettingsWindow(AppConfig config)
+    {
+        _config = config;
+        InitializeComponent();
+        Populate();
+    }
+
+    private void Populate()
+    {
+        _loading = true;
+
+        HotkeyLabel.Text = HotkeyBinding.Display(HotkeyBinding.Parse(_config.StartStopHotkey));
+        DebugHotkeyLabel.Text = HotkeyBinding.Display(HotkeyBinding.Parse(_config.DebugHotkey));
+        CalibrateHotkeyLabel.Text = HotkeyBinding.Display(HotkeyBinding.Parse(_config.CalibrateHotkey));
+
+        ThemeBox.ItemsSource = ThemePresets.Names;
+        ThemeBox.SelectedItem = ThemePresets.Resolve(_config.Theme);
+
+        // Two backends: "GDI" forces legacy BitBlt; anything else is WGC (GPU) with GDI fallback.
+        // Tag carries the value persisted to config.CaptureBackend.
+        CaptureBox.Items.Clear();
+        CaptureBox.Items.Add(new ComboBoxItem { Content = "Auto (GPU + fallback)", Tag = "Auto" });
+        CaptureBox.Items.Add(new ComboBoxItem { Content = "Legacy (GDI)", Tag = "GDI" });
+        CaptureBox.SelectedIndex = _config.CaptureBackend == "GDI" ? 1 : 0;
+
+        AutoStartBox.IsChecked = _config.AutoStart;
+
+        _loading = false;
+    }
+
+    protected override void OnKeyDown(System.Windows.Input.KeyEventArgs e)
+    {
+        // Esc closes — but not while a rebind capture is listening (Esc cancels that instead, handled
+        // on the global hook), so don't steal it mid-rebind.
+        if (e.Key == System.Windows.Input.Key.Escape && _rebindButton is null) Close();
+        base.OnKeyDown(e);
+    }
+
+    private void ThemeBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_loading || ThemeBox.SelectedItem is not string theme) return;
+        _config.Theme = theme;
+        ConfigStore.Save(_config);
+        ThemePresets.Apply(theme);   // app-wide, so the main window updates live too
+    }
+
+    private void CaptureBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_loading || CaptureBox.SelectedItem is not ComboBoxItem { Tag: string value }) return;
+        _config.CaptureBackend = value;
+        ConfigStore.Save(_config);   // read by the engine the next time it starts
+    }
+
+    private void AutoStartBox_Changed(object sender, RoutedEventArgs e)
+    {
+        if (_loading) return;
+        _config.AutoStart = AutoStartBox.IsChecked == true;
+        ConfigStore.Save(_config);
+    }
+
+    // ---- Hotkey rebinding (moved verbatim from MainWindow; one capture at a time) ----
+
+    private HotkeyBinding.Action _rebindAction;
+    private Button? _rebindButton;
+    private TextBlock? _rebindLabel;
+
+    private void RebindButton_Click(object sender, RoutedEventArgs e) =>
+        BeginRebind(HotkeyBinding.Action.StartStop, RebindButton, HotkeyLabel);
+
+    private void RebindDebugButton_Click(object sender, RoutedEventArgs e) =>
+        BeginRebind(HotkeyBinding.Action.Debug, RebindDebugButton, DebugHotkeyLabel);
+
+    private void RebindCalibrateButton_Click(object sender, RoutedEventArgs e) =>
+        BeginRebind(HotkeyBinding.Action.Calibrate, RebindCalibrateButton, CalibrateHotkeyLabel);
+
+    private void BeginRebind(HotkeyBinding.Action action, Button button, TextBlock label)
+    {
+        _rebindAction = action;
+        _rebindButton = button;
+        _rebindLabel = label;
+        SetRebindButtonsEnabled(false);
+        button.Content = "Press a key… (Esc to cancel)";
+        App.BeginHotkeyCapture(action, OnHotkeyCaptured);   // outcome arrives on the UI thread
+    }
+
+    private void OnHotkeyCaptured(App.CaptureOutcome outcome, KeyCode code)
+    {
+        switch (outcome)
+        {
+            case App.CaptureOutcome.Captured:
+                switch (_rebindAction)
+                {
+                    case HotkeyBinding.Action.StartStop:
+                        _config.StartStopHotkey = HotkeyBinding.ToStorage(code);
+                        App.SetStartStopKey(code);
+                        break;
+                    case HotkeyBinding.Action.Debug:
+                        _config.DebugHotkey = HotkeyBinding.ToStorage(code);
+                        App.SetDebugKey(code);
+                        break;
+                    case HotkeyBinding.Action.Calibrate:
+                        _config.CalibrateHotkey = HotkeyBinding.ToStorage(code);
+                        App.SetCalibrateKey(code);
+                        break;
+                }
+                ConfigStore.Save(_config);
+                if (_rebindLabel is not null) _rebindLabel.Text = HotkeyBinding.Display(code);
+                EndRebind();
+                break;
+            case App.CaptureOutcome.Reserved:
+                if (_rebindButton is not null)
+                    _rebindButton.Content = $"{HotkeyBinding.Display(code)} is in use — try another";
+                break;
+            case App.CaptureOutcome.Cancelled:
+                EndRebind();
+                break;
+        }
+    }
+
+    private void EndRebind()
+    {
+        if (_rebindButton is not null) _rebindButton.Content = "Rebind";
+        _rebindButton = null;
+        _rebindLabel = null;
+        SetRebindButtonsEnabled(true);
+    }
+
+    private void SetRebindButtonsEnabled(bool enabled)
+    {
+        RebindButton.IsEnabled = enabled;
+        RebindDebugButton.IsEnabled = enabled;
+        RebindCalibrateButton.IsEnabled = enabled;
+    }
+}

--- a/src/PoeAncientsPriceHelper/ThemePresets.cs
+++ b/src/PoeAncientsPriceHelper/ThemePresets.cs
@@ -1,0 +1,57 @@
+using System.Windows;
+
+// System.Drawing (WinForms) and System.Windows.Media both define Brush/Color, so the Media types are
+// aliased here to keep the preset table readable. Only the WPF window background is themed.
+using Brush = System.Windows.Media.Brush;
+using Color = System.Windows.Media.Color;
+using SolidColorBrush = System.Windows.Media.SolidColorBrush;
+using LinearGradientBrush = System.Windows.Media.LinearGradientBrush;
+
+namespace PoeAncientsPriceHelper;
+
+// Dark-theme presets, shared by every window. Apply() writes the chosen background onto
+// Application.Current.Resources so the DynamicResource binding on each window's Background updates
+// live across the whole app — the main window and the (separate) settings window stay in sync when
+// the theme is changed. A key set directly on Application.Resources overrides the same key supplied
+// by the merged WPF-UI ThemesDictionary. Only the window background changes; the FlatButton colors
+// are hardcoded and never themed.
+internal static class ThemePresets
+{
+    public const string Default = "Toxic";
+    public const string BackgroundKey = "ApplicationBackgroundBrush";
+
+    public static readonly (string Name, Brush Background)[] All =
+    [
+        ("Midnight", Solid(0x1C, 0x1C, 0x1C)),
+        ("Obsidian", Gradient(0x05, 0x05, 0x05, 0x14, 0x14, 0x14)),
+        ("Abyss",    Gradient(0x0A, 0x0F, 0x1E, 0x0D, 0x15, 0x28)),
+        ("Ember",    Gradient(0x1A, 0x0F, 0x08, 0x0F, 0x08, 0x05)),
+        ("Toxic",    Gradient(0x0A, 0x12, 0x08, 0x0D, 0x1A, 0x0A)),
+    ];
+
+    public static string[] Names => All.Select(t => t.Name).ToArray();
+
+    // Falls back to the default preset when the saved name is unknown (e.g. a renamed/removed theme).
+    public static string Resolve(string? saved) => All.Any(t => t.Name == saved) ? saved! : Default;
+
+    public static void Apply(string name)
+    {
+        var preset = Array.Find(All, t => t.Name == name);
+        if (preset.Name is null) return;
+        System.Windows.Application.Current.Resources[BackgroundKey] = preset.Background;
+    }
+
+    private static Brush Solid(byte r, byte g, byte b)
+    {
+        var brush = new SolidColorBrush(Color.FromRgb(r, g, b));
+        brush.Freeze();
+        return brush;
+    }
+
+    private static Brush Gradient(byte r1, byte g1, byte b1, byte r2, byte g2, byte b2)
+    {
+        var brush = new LinearGradientBrush(Color.FromRgb(r1, g1, b1), Color.FromRgb(r2, g2, b2), 90);
+        brush.Freeze();
+        return brush;
+    }
+}


### PR DESCRIPTION
## Summary

Quality-of-life pass that declutters the main window, makes the app start itself, and hardens price fetching. Five focused commits:

1. **`feat`: in-app Diagnostics link** — relaunches with `--debug` so users can capture `scan_log.txt` / `debug_ocr.png` for bug reports (the old `debug.cmd` no longer ships with the Velopack build). When already in debug mode the link instead opens the data folder. Releases the single-instance mutex first so the relaunched copy can take it.

2. **`refactor`: dedicated Settings window** — moves the three hotkey rebinds and the theme picker off the main window into a modal gear-opened dialog, and surfaces two previously UI-less options: **Capture mode** (Auto/WGC vs GDI, applied on next start) and an **Auto-start** toggle. Theme application moves to a shared `ThemePresets` helper that writes to `Application.Current.Resources`, keeping both windows in sync live.

3. **`feat`: auto-start + minimize** — with a calibrated region and the (default-on) auto-start option, the app begins scanning and drops to the tray on launch. Skipped under `--debug` and when uncalibrated.

4. **`feat`: resilient price fetching** — a fetch that yields zero usable items now keeps the last-good prices instead of overwriting them with an empty set (fixes a blank-out bug), retries every 30s until prices return then falls back to 30 min, and the status label shows clear red / amber / normal states. Matters now that auto-start can hide the app in the tray.

5. **`fix`**: enlarge the Settings window so the auto-start toggle isn't clipped.

## Testing

- `dotnet build` clean (0 warnings)
- **100/100 tests pass**
- Both windows verified visually (main window decluttered with gear; Settings window renders all controls including the auto-start toggle)

## Notes

- New `AppConfig.AutoStart` (default `true`; missing in older configs → on).
- No behavior change for `--debug` sessions (window + console stay visible).
