### PR TITLE
fix(net): Happy Eyeballs connect so dead IPv6 doesn't stall poe.ninja fetches (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [3.5.7] — 2026-07-03
+
+### Fixed
+
+- **Prices now load on connections with broken IPv6 (Starlink/CGNAT).** `poe.ninja`/`poecdn`
+  publish both IPv6 and IPv4 addresses; on connections where the IPv6 path is a black hole, the app
+  used to stall on the dead route until the 15s timeout fired and the whole fetch cycle failed. Network
+  connections now use a Happy Eyeballs (RFC 8305) racing connect that falls back to IPv4 in a fraction
+  of a second — no firewall rule needed. Healthy connections are unaffected. (#16)
+
 ## [3.5.6] — 2026-07-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,6 +58,42 @@ The app updates itself straight from this repo's GitHub Releases — there's no 
 
 Updating is powered by [Velopack](https://velopack.io/) (see [Acknowledgements](#acknowledgements)).
 
+## Troubleshooting
+
+### Prices won't load / poe.ninja fetches keep failing
+
+On some connections (Starlink and other CGNAT setups are the usual culprits) the IPv6 network path
+is broken even though IPv4 works fine. Since `poe.ninja` resolves to both IPv6 and IPv4 addresses,
+the app can end up trying the dead IPv6 route and stalling until each request times out — so prices
+never appear.
+
+**As of v3.5.7 this is handled automatically** — the app races the IPv4 and IPv6 routes and uses
+whichever connects first, so a dead IPv6 path falls back to IPv4 on its own. Just update and it
+should work; no firewall rule needed.
+
+If you're on an older version and can't update, you can force the app onto IPv4 by blocking its
+outbound IPv6 traffic with a firewall rule. Open **Windows PowerShell as Administrator** and run:
+
+```powershell
+New-NetFirewallRule -DisplayName "Block IPv6 - PoeAncientsPriceHelper" `
+  -Direction Outbound `
+  -Program "C:\Users\<YOUR-USERNAME>\AppData\Local\PoeAncientsPriceHelper\current\PoeAncientsPriceHelper.exe" `
+  -RemoteAddress "::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" `
+  -Protocol TCP `
+  -Action Block
+```
+
+Replace `<YOUR-USERNAME>` with your Windows username (the path above is the default install
+location). Restart the app and prices should load over IPv4.
+
+To undo it later:
+
+```powershell
+Remove-NetFirewallRule -DisplayName "Block IPv6 - PoeAncientsPriceHelper"
+```
+
+> Thanks to the community for diagnosing this one.
+
 ## Build from source
 
 Requires the **.NET 10 SDK** ([download](https://dotnet.microsoft.com/en-us/download/dotnet/10.0))

--- a/src/PoeAncientsPriceHelper.Tests/HappyEyeballsTests.cs
+++ b/src/PoeAncientsPriceHelper.Tests/HappyEyeballsTests.cs
@@ -1,0 +1,96 @@
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using PoeAncientsPriceHelper;
+
+namespace PoeAncientsPriceHelper.Tests;
+
+// #16: verify the Happy Eyeballs connect races address families and doesn't stall on a dead one.
+// The per-address connect is stubbed so a "black hole" (a connect that never completes until it is
+// cancelled) is deterministic, without depending on the host's actual IPv6 routing.
+public class HappyEyeballsTests : IDisposable
+{
+    private static readonly IPAddress V6 = IPAddress.Parse("2001:db8::1"); // documentation range, unroutable
+    private static readonly IPAddress V4 = IPAddress.Parse("93.184.216.34");
+
+    private readonly Func<string, CancellationToken, Task<IPAddress[]>> _origResolve = HappyEyeballs.Resolve;
+    private readonly Func<IPAddress, int, CancellationToken, Task<Stream>> _origConnect = HappyEyeballs.ConnectStream;
+
+    public void Dispose()
+    {
+        HappyEyeballs.Resolve = _origResolve;
+        HappyEyeballs.ConnectStream = _origConnect;
+    }
+
+    // A stream we can identify by reference so tests can assert which family won.
+    private sealed class TaggedStream(IPAddress address) : MemoryStream
+    {
+        public IPAddress Address { get; } = address;
+    }
+
+    [Fact]
+    public async Task Falls_back_to_IPv4_when_IPv6_black_holes()
+    {
+        HappyEyeballs.Resolve = (_, _) => Task.FromResult(new[] { V6, V4 });
+        var v6Cancelled = false;
+        HappyEyeballs.ConnectStream = async (addr, _, ct) =>
+        {
+            if (addr.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                // Never connects — simulates a black-holed SYN that only ends when we cancel it.
+                try { await Task.Delay(Timeout.Infinite, ct); }
+                catch (OperationCanceledException) { v6Cancelled = true; throw; }
+            }
+            return new TaggedStream(addr);
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var stream = await HappyEyeballs.ConnectAsync(new DnsEndPoint("poe.ninja", 443), cts.Token);
+
+        var tagged = Assert.IsType<TaggedStream>(stream);
+        Assert.Equal(AddressFamily.InterNetwork, tagged.Address.AddressFamily);
+        // Give the cancelled loser a moment to observe the cancellation.
+        await Task.Delay(100);
+        Assert.True(v6Cancelled, "the losing IPv6 attempt should have been cancelled");
+    }
+
+    [Fact]
+    public async Task Healthy_first_address_wins_without_opening_a_second_socket()
+    {
+        HappyEyeballs.Resolve = (_, _) => Task.FromResult(new[] { V6, V4 });
+        var attempts = 0;
+        HappyEyeballs.ConnectStream = (addr, _, _) =>
+        {
+            Interlocked.Increment(ref attempts);
+            return Task.FromResult<Stream>(new TaggedStream(addr));
+        };
+
+        var stream = await HappyEyeballs.ConnectAsync(new DnsEndPoint("poe.ninja", 443), default);
+
+        var tagged = Assert.IsType<TaggedStream>(stream);
+        Assert.Equal(AddressFamily.InterNetworkV6, tagged.Address.AddressFamily); // v6 preferred, wins instantly
+        Assert.Equal(1, attempts); // second family never dialled in the common case
+    }
+
+    [Fact]
+    public async Task Surfaces_the_error_when_every_address_fails()
+    {
+        HappyEyeballs.Resolve = (_, _) => Task.FromResult(new[] { V4 });
+        HappyEyeballs.ConnectStream = (_, _, _) =>
+            Task.FromException<Stream>(new SocketException((int)SocketError.ConnectionRefused));
+
+        var ex = await Assert.ThrowsAsync<SocketException>(
+            () => HappyEyeballs.ConnectAsync(new DnsEndPoint("poe.ninja", 443), default).AsTask());
+        Assert.Equal(SocketError.ConnectionRefused, ex.SocketErrorCode);
+    }
+
+    [Fact]
+    public async Task Throws_HostNotFound_when_DNS_returns_nothing()
+    {
+        HappyEyeballs.Resolve = (_, _) => Task.FromResult(Array.Empty<IPAddress>());
+
+        var ex = await Assert.ThrowsAsync<SocketException>(
+            () => HappyEyeballs.ConnectAsync(new DnsEndPoint("nope.invalid", 443), default).AsTask());
+        Assert.Equal(SocketError.HostNotFound, ex.SocketErrorCode);
+    }
+}

--- a/src/PoeAncientsPriceHelper/HappyEyeballs.cs
+++ b/src/PoeAncientsPriceHelper/HappyEyeballs.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace PoeAncientsPriceHelper;
+
+// Fixes stalled poe.ninja/poecdn fetches on connections where one IP family (usually IPv6 on
+// Starlink/CGNAT) is a black hole (#16). Those hosts publish both AAAA and A records; the default
+// SocketsHttpHandler connect tries addresses in DNS order, so a dead IPv6 SYN hangs until our 15s
+// HttpClient timeout fires and the whole fetch cycle fails.
+//
+// This is a compact RFC 8305 "Happy Eyeballs": resolve the host, then start a TCP connect per
+// address staggered by a short delay, racing them. Whichever connects first wins; the losers are
+// cancelled and disposed. A dead family loses the race in ~one stagger interval instead of eating
+// the timeout, and a healthy connection is unaffected (its attempt starts first and normally wins
+// before any second socket is even opened). Covers the reverse case (dead IPv4, healthy IPv6) too.
+internal static class HappyEyeballs
+{
+    // Delay before starting the next address's attempt. RFC 8305 suggests 150–250ms: short enough to
+    // stay snappy when the first family is dead, long enough that a healthy first attempt normally
+    // wins outright so we don't open throwaway sockets in the common case.
+    private static readonly TimeSpan AttemptStagger = TimeSpan.FromMilliseconds(200);
+
+    // Seams for tests: swap in a fixed address list (incl. an unreachable family) and a fake connect
+    // so the race/fallback logic can be exercised deterministically without real DNS or sockets.
+    internal static Func<string, CancellationToken, Task<IPAddress[]>> Resolve { get; set; } =
+        static (host, ct) => Dns.GetHostAddressesAsync(host, ct);
+
+    internal static Func<IPAddress, int, CancellationToken, Task<Stream>> ConnectStream { get; set; } =
+        DefaultConnectAsync;
+
+    // ConnectCallback signature: (context, ct) => ValueTask<Stream>.
+    public static async ValueTask<Stream> ConnectAsync(DnsEndPoint endPoint, CancellationToken ct)
+    {
+        var addresses = await Resolve(endPoint.Host, ct).ConfigureAwait(false);
+        if (addresses.Length == 0)
+            throw new SocketException((int)SocketError.HostNotFound);
+
+        var ordered = Interleave(addresses);
+
+        // Cancels the losing attempts (and the pending stagger delay) once we have a winner or bail.
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var pending = new List<Task<Stream>>(ordered.Count);
+        List<Exception>? failures = null;
+        Task? stagger = null;
+        var next = 0;
+
+        while (next < ordered.Count || pending.Count > 0)
+        {
+            // Launch the next attempt when nothing is staggered ahead of it (first attempt, or the
+            // previous stagger has elapsed). After launching, arm a fresh stagger for the one after.
+            if (next < ordered.Count && stagger is null)
+            {
+                pending.Add(ConnectStream(ordered[next], endPoint.Port, linked.Token));
+                next++;
+                stagger = next < ordered.Count ? Task.Delay(AttemptStagger, linked.Token) : null;
+            }
+
+            var waitSet = new List<Task>(pending);
+            if (stagger is not null) waitSet.Add(stagger);
+
+            var done = await Task.WhenAny(waitSet).ConfigureAwait(false);
+
+            if (done == stagger)
+            {
+                // Stagger elapsed with no winner yet — time to start the next address.
+                stagger = null;
+                continue;
+            }
+
+            var attempt = (Task<Stream>)done;
+            pending.Remove(attempt);
+
+            if (attempt.IsCompletedSuccessfully)
+            {
+                var winner = attempt.Result;
+                linked.Cancel();          // stop the stagger + the losing connects
+                DisposeLosers(pending);   // dispose any that also connected in the race
+                return winner;
+            }
+
+            // This address failed (refused/unreachable). Remember why, keep racing the rest.
+            (failures ??= []).Add(attempt.Exception?.InnerException ?? attempt.Exception!);
+        }
+
+        // Every address failed. Surface the underlying reason(s).
+        ct.ThrowIfCancellationRequested();
+        throw failures is { Count: 1 }
+            ? failures[0]
+            : new AggregateException($"Could not connect to {endPoint.Host}:{endPoint.Port}.", failures ?? []);
+    }
+
+    // Interleave families (v6, v4, v6, v4, …) so a healthy family is always tried early even when DNS
+    // returned the other family's addresses first. IPv6 leads per RFC 8305's preference.
+    private static List<IPAddress> Interleave(IPAddress[] addresses)
+    {
+        var v6 = new Queue<IPAddress>();
+        var v4 = new Queue<IPAddress>();
+        foreach (var a in addresses)
+            (a.AddressFamily == AddressFamily.InterNetworkV6 ? v6 : v4).Enqueue(a);
+
+        var ordered = new List<IPAddress>(addresses.Length);
+        while (v6.Count > 0 || v4.Count > 0)
+        {
+            if (v6.Count > 0) ordered.Add(v6.Dequeue());
+            if (v4.Count > 0) ordered.Add(v4.Dequeue());
+        }
+        return ordered;
+    }
+
+    // Observe and dispose losing attempts in the background so a socket that connects just after we
+    // picked a winner is closed (and its exception, if any, never goes unobserved).
+    private static void DisposeLosers(List<Task<Stream>> losers)
+    {
+        foreach (var loser in losers)
+        {
+            _ = loser.ContinueWith(static t =>
+            {
+                if (t.IsCompletedSuccessfully) t.Result.Dispose();
+                else _ = t.Exception; // observe
+            }, TaskScheduler.Default);
+        }
+    }
+
+    private static async Task<Stream> DefaultConnectAsync(IPAddress address, int port, CancellationToken ct)
+    {
+        var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        try
+        {
+            await socket.ConnectAsync(address, port, ct).ConfigureAwait(false);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+}

--- a/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
+++ b/src/PoeAncientsPriceHelper/MainWindow.xaml.cs
@@ -28,7 +28,10 @@ public partial class MainWindow : Window
     {
         AutomaticDecompression = System.Net.DecompressionMethods.All,
         PooledConnectionLifetime = TimeSpan.FromMinutes(5),
-        MaxConnectionsPerServer = 4
+        MaxConnectionsPerServer = 4,
+        // Happy Eyeballs (#16): race IPv4/IPv6 connects so a dead IPv6 path (Starlink/CGNAT) falls
+        // back to IPv4 in a fraction of a second instead of stalling out the 15s timeout below.
+        ConnectCallback = static (context, ct) => HappyEyeballs.ConnectAsync(context.DnsEndPoint, ct)
     })
     {
         Timeout = TimeSpan.FromSeconds(15),

--- a/src/PoeAncientsPriceHelper/PoeAncientsPriceHelper.csproj
+++ b/src/PoeAncientsPriceHelper/PoeAncientsPriceHelper.csproj
@@ -23,7 +23,7 @@
     <AssemblyTitle>Poe Ancients Price Helper</AssemblyTitle>
     <Product>Poe Ancients Price Helper</Product>
     <Description>Screen overlay for Path of Exile 2 that OCRs the currency-exchange panel and shows live poe.ninja prices.</Description>
-    <Version>3.5.6</Version>
+    <Version>3.5.7</Version>
     <Authors>pedro</Authors>
     <Company>pedro</Company>
     <Copyright>Copyright © 2026 pedro</Copyright>


### PR DESCRIPTION
## Summary

Fixes poe.ninja price fetches stalling on connections with a broken IPv6 path (Starlink / other CGNAT setups). `poe.ninja`/`poecdn` publish both AAAA and A records; the default `SocketsHttpHandler` connect tried addresses in DNS order, so a dead IPv6 SYN black-holed and the request hung until the 15s `HttpClient` timeout fired — failing the whole fetch cycle.

Closes #16.

## What changed

- **New `HappyEyeballs.ConnectAsync`** (RFC 8305 staggered race): resolve the host → interleave families (IPv6 first) → start a TCP connect per address 200 ms apart → take whichever connects first, cancel and dispose the losers.
- Wired as a `ConnectCallback` on the **single shared `_http` handler** in `MainWindow`, so `PriceRepository` / `IconCache` / `RumourRefresher` all benefit (`NameTranslator` does no network).
- Only the TCP connect changed — **HTTP/2, `AutomaticDecompression`, and connection pooling are untouched.**
- .NET 10's `SocketsHttpHandler` still ships no built-in Happy Eyeballs, so the custom callback is required.

## Behaviour

- **Dead IPv6 path** → falls back to IPv4 in ~one stagger interval instead of eating the 15s timeout.
- **Healthy connection** → the first attempt normally wins before a second socket is even opened — no added latency in the common case.
- Covers the reverse case (dead IPv4, healthy IPv6) for free.

## Tests

- `HappyEyeballsTests`: black-hole IPv6 → IPv4 fallback, healthy-first wins without opening a second socket, all-addresses-fail surfaces the underlying error, empty-DNS → `HostNotFound`.
- Full suite green (243 tests).
- Verified against **live poe.ninja** with the exact production handler config: site root and the real price API both returned `200 OK` over HTTP/2 (~160–210 ms).

## Docs

- `CHANGELOG.md` entry for 3.5.7.
- README troubleshooting updated: the firewall workaround is now marked as only needed on older versions.
